### PR TITLE
Update button styling

### DIFF
--- a/frontend/src/atoms/Button/Button.test.tsx
+++ b/frontend/src/atoms/Button/Button.test.tsx
@@ -86,7 +86,7 @@ describe('Button', () => {
         <Button variant="icon" intent="success" LeftIcon={MockIcon} aria-label="Icon" />,
       );
       const button = screen.getByRole('button', { name: /icon/i });
-      expect(button.className).toContain('text-success');
+      expect(button.className).toContain('bg-success');
     });
   });
 

--- a/frontend/src/atoms/Button/Button.tsx
+++ b/frontend/src/atoms/Button/Button.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@/atoms/Spinner/Spinner';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'group inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-secondary disabled:pointer-events-none disabled:opacity-50 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm active:scale-[0.98]',
+  'group inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium shadow-sm ring-offset-background transition-all duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-secondary disabled:pointer-events-none disabled:opacity-50 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm active:scale-[0.98]',
   {
     variants: {
       variant: {
@@ -43,11 +43,11 @@ const buttonVariants = cva(
       { variant: 'icon', size: 'sm', className: 'w-9' },
       { variant: 'icon', size: 'md', className: 'w-10' },
       { variant: 'icon', size: 'lg', className: 'w-11' },
-      { variant: 'icon', intent: 'primary', className: 'text-primary' },
-      { variant: 'icon', intent: 'secondary', className: 'text-secondary' },
-      { variant: 'icon', intent: 'tertiary', className: 'text-tertiary' },
-      { variant: 'icon', intent: 'quaternary', className: 'text-quaternary' },
-      { variant: 'icon', intent: 'success', className: 'text-success' },
+      { variant: 'icon', intent: 'primary', className: 'bg-primary text-primary-foreground' },
+      { variant: 'icon', intent: 'secondary', className: 'bg-secondary text-primary-foreground' },
+      { variant: 'icon', intent: 'tertiary', className: 'bg-tertiary text-primary-foreground' },
+      { variant: 'icon', intent: 'quaternary', className: 'bg-quaternary text-primary-foreground' },
+      { variant: 'icon', intent: 'success', className: 'bg-success text-primary-foreground' },
       // Outline variant styles
       { variant: 'outline', intent: 'primary', className: 'border-primary text-primary hover:bg-primary hover:text-primary-foreground' },
       { variant: 'outline', intent: 'secondary', className: 'border-secondary text-secondary hover:bg-secondary hover:text-secondary-foreground' },

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -115,7 +115,7 @@ export const tokens = {
     sm: "0 1px 2px 0 rgb(0 0 0 / 0.05)",
     md: "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
     lg: "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
-    glass: "0 8px 32px rgba(31, 38, 135, 0.37)",
+    glass: "0 4px 16px rgba(31, 38, 135, 0.25)",
   },
   fontFamily: {
     sans: ['"Cairo Play"', 'ui-sans-serif', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
## Summary
- tweak button base to include subtle shadow
- recolor icon-only variant container instead of icon
- soften glass shadow in theme
- adjust tests for new icon-only coloring

## Testing
- `npm run test --prefix frontend -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6865d9ca26c4832ba3f2633bb9c5d38d