### PR TITLE
Enhance input atom

### DIFF
--- a/frontend/src/atoms/Input/Input.stories.tsx
+++ b/frontend/src/atoms/Input/Input.stories.tsx
@@ -18,6 +18,12 @@ const meta: Meta<InputStoryProps> = {
     disabled: { control: 'boolean' },
     error: { control: 'boolean' },
     placeholder: { control: 'text' },
+    label: { control: 'text' },
+    showCharCount: { control: 'boolean' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+    },
     leftIconName: { name: 'Left Icon', control: 'select', options: [undefined, ...iconOptions] },
     rightIconName: { name: 'Right Icon', control: 'select', options: [undefined, ...iconOptions] },
     LeftIcon: { table: { disable: true } },
@@ -38,3 +44,7 @@ export const WithError: Story = { args: { placeholder: 'Invalid', error: true } 
 export const Disabled: Story = { args: { placeholder: 'Disabled', disabled: true } };
 export const Small: Story = { args: { size: 'sm', placeholder: 'Small size' } };
 export const Large: Story = { args: { size: 'lg', placeholder: 'Large size' } };
+export const WithLabel: Story = { args: { label: 'Email', color: 'secondary' } };
+export const WithCounter: Story = {
+  args: { label: 'Bio', showCharCount: true, maxLength: 50, color: 'tertiary' },
+};

--- a/frontend/src/atoms/Input/Input.test.tsx
+++ b/frontend/src/atoms/Input/Input.test.tsx
@@ -46,4 +46,16 @@ describe('Input', () => {
     expect(handleChange).toHaveBeenCalled();
     expect((input as HTMLInputElement).value).toBe('hi');
   });
+
+  it('renders floating label', () => {
+    render(<Input label="Email" id="email" />);
+    expect(screen.getByText('Email')).toHaveAttribute('for', 'email');
+  });
+
+  it('shows character count', () => {
+    render(<Input showCharCount label="Bio" maxLength={10} />);
+    const input = screen.getByLabelText('Bio');
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(screen.getByText('3/10')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- tweak placeholder color and make outline configurable
- add optional floating label with animation
- change icon color on focus via group styles
- support character count and expose storybook examples
- test new label and counter features

## Testing
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865f2ecb298832b8c41c02740bfeb11