### PR TITLE
Add icon button variants for Input

### DIFF
--- a/frontend/src/atoms/Input/Input.stories.tsx
+++ b/frontend/src/atoms/Input/Input.stories.tsx
@@ -1,50 +1,110 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Input, InputProps } from './Input';
-import { iconMap, IconName } from './icons';
+import type { Meta, StoryObj } from "@storybook/react";
+import { Input, InputProps } from "./Input";
+import { iconMap, IconName } from "./icons";
 
 interface InputStoryProps extends InputProps {
   leftIconName?: IconName;
   rightIconName?: IconName;
+  rightButtonName?: IconName;
 }
 
 const iconOptions = Object.keys(iconMap) as IconName[];
 
 const meta: Meta<InputStoryProps> = {
-  title: 'Atoms/Input',
+  title: "Atoms/Input",
   component: Input,
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   argTypes: {
-    size: { control: 'select', options: ['sm', 'md', 'lg'] },
-    disabled: { control: 'boolean' },
-    error: { control: 'boolean' },
-    placeholder: { control: 'text' },
-    label: { control: 'text' },
-    showCharCount: { control: 'boolean' },
+    size: { control: "select", options: ["sm", "md", "lg"] },
+    disabled: { control: "boolean" },
+    error: { control: "boolean" },
+    placeholder: { control: "text" },
+    label: { control: "text" },
+    showCharCount: { control: "boolean" },
     color: {
-      control: 'select',
-      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "tertiary",
+        "quaternary",
+        "success",
+        "destructive",
+      ],
     },
-    leftIconName: { name: 'Left Icon', control: 'select', options: [undefined, ...iconOptions] },
-    rightIconName: { name: 'Right Icon', control: 'select', options: [undefined, ...iconOptions] },
+    leftIconName: {
+      name: "Left Icon",
+      control: "select",
+      options: [undefined, ...iconOptions],
+    },
+    rightIconName: {
+      name: "Right Icon",
+      control: "select",
+      options: [undefined, ...iconOptions],
+    },
+    rightButtonName: {
+      name: "Right Button",
+      control: "select",
+      options: [undefined, ...iconOptions],
+    },
     LeftIcon: { table: { disable: true } },
     RightIcon: { table: { disable: true } },
+    RightButton: { table: { disable: true } },
   },
-  render: ({ leftIconName, rightIconName, ...args }) => {
+  render: ({ leftIconName, rightIconName, rightButtonName, ...args }) => {
     const LeftIcon = leftIconName ? iconMap[leftIconName] : undefined;
     const RightIcon = rightIconName ? iconMap[rightIconName] : undefined;
-    return <Input {...args} LeftIcon={LeftIcon} RightIcon={RightIcon} />;
+    const RightButton = rightButtonName ? iconMap[rightButtonName] : undefined;
+    return (
+      <Input
+        {...args}
+        LeftIcon={LeftIcon}
+        RightIcon={RightIcon}
+        RightButton={RightButton}
+      />
+    );
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = { args: { placeholder: 'Enter text' } };
-export const WithError: Story = { args: { placeholder: 'Invalid', error: true } };
-export const Disabled: Story = { args: { placeholder: 'Disabled', disabled: true } };
-export const Small: Story = { args: { size: 'sm', placeholder: 'Small size' } };
-export const Large: Story = { args: { size: 'lg', placeholder: 'Large size' } };
-export const WithLabel: Story = { args: { label: 'Email', color: 'secondary' } };
+export const Default: Story = { args: { placeholder: "Enter text" } };
+export const WithError: Story = {
+  args: { placeholder: "Invalid", error: true },
+};
+export const Disabled: Story = {
+  args: { placeholder: "Disabled", disabled: true },
+};
+export const Small: Story = { args: { size: "sm", placeholder: "Small size" } };
+export const Large: Story = { args: { size: "lg", placeholder: "Large size" } };
+export const WithLabel: Story = {
+  args: { label: "Email", color: "secondary" },
+};
 export const WithCounter: Story = {
-  args: { label: 'Bio', showCharCount: true, maxLength: 50, color: 'tertiary' },
+  args: { label: "Bio", showCharCount: true, maxLength: 50, color: "tertiary" },
+};
+
+export const SearchBar: Story = {
+  args: {
+    placeholder: "Buscar...",
+    leftIconName: "Search",
+    color: "primary",
+  },
+};
+
+export const WithUploadButton: Story = {
+  args: {
+    placeholder: "Subir documento",
+    rightButtonName: "Upload",
+    color: "secondary",
+  },
+};
+
+export const WithRecordButton: Story = {
+  args: {
+    placeholder: "Grabar audio",
+    rightButtonName: "Mic",
+    color: "secondary",
+  },
 };

--- a/frontend/src/atoms/Input/Input.tsx
+++ b/frontend/src/atoms/Input/Input.tsx
@@ -1,50 +1,58 @@
-import * as React from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '@/lib/utils';
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const inputVariants = cva(
-  'peer block w-full rounded-md border border-border bg-white text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50',
+  "peer block w-full rounded-md border border-border bg-white text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       size: {
-        sm: 'py-1 px-2 text-sm',
-        md: 'py-2 px-3 text-base',
-        lg: 'py-3 px-4 text-lg',
+        sm: "py-1 px-2 text-sm",
+        md: "py-2 px-3 text-base",
+        lg: "py-3 px-4 text-lg",
       },
       leftIcon: {
-        true: 'pl-10',
+        true: "pl-10",
       },
       rightIcon: {
-        true: 'pr-10',
+        true: "pr-10",
+      },
+      rightButton: {
+        true: "pr-14",
       },
       color: {
-        primary: 'border-primary focus:ring-primary',
-        secondary: 'border-secondary focus:ring-secondary',
-        tertiary: 'border-tertiary focus:ring-tertiary',
-        quaternary: 'border-quaternary focus:ring-quaternary',
-        success: 'border-success focus:ring-success',
-        destructive: 'border-destructive focus:ring-destructive',
+        primary: "border-primary focus:ring-primary",
+        secondary: "border-secondary focus:ring-secondary",
+        tertiary: "border-tertiary focus:ring-tertiary",
+        quaternary: "border-quaternary focus:ring-quaternary",
+        success: "border-success focus:ring-success",
+        destructive: "border-destructive focus:ring-destructive",
       },
       error: {
-        true: 'border-destructive focus:ring-destructive',
+        true: "border-destructive focus:ring-destructive",
       },
     },
     defaultVariants: {
-      size: 'md',
-      color: 'primary',
+      size: "md",
+      color: "primary",
     },
-  }
+  },
 );
 
 export interface InputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>,
-    Omit<VariantProps<typeof inputVariants>, 'error' | 'leftIcon' | 'rightIcon'> {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+    Omit<
+      VariantProps<typeof inputVariants>,
+      "error" | "leftIcon" | "rightIcon"
+    > {
   LeftIcon?: React.ElementType;
   RightIcon?: React.ElementType;
+  RightButton?: React.ElementType;
+  onRightButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
   error?: boolean;
   label?: string;
   showCharCount?: boolean;
-  color?: VariantProps<typeof inputVariants>['color'];
+  color?: VariantProps<typeof inputVariants>["color"];
 }
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -54,6 +62,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       size,
       LeftIcon,
       RightIcon,
+      RightButton,
+      onRightButtonClick,
       error,
       label,
       showCharCount,
@@ -62,13 +72,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       id,
       ...props
     },
-    ref
+    ref,
   ) => {
-    const iconSize = size === 'lg' ? 20 : size === 'md' ? 18 : 16;
+    const iconSize = size === "lg" ? 20 : size === "md" ? 18 : 16;
     const hasLeft = Boolean(LeftIcon);
     const hasRight = Boolean(RightIcon);
+    const hasRightButton = Boolean(RightButton);
     const [count, setCount] = React.useState(
-      (props.value ?? props.defaultValue ?? '').toString().length
+      (props.value ?? props.defaultValue ?? "").toString().length,
     );
 
     const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -78,24 +89,27 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       }
     };
 
-    const inputId = id || label ? `${id ?? label?.replace(/\s+/g, '-').toLowerCase()}` : undefined;
+    const inputId =
+      id || label
+        ? `${id ?? label?.replace(/\s+/g, "-").toLowerCase()}`
+        : undefined;
     const iconFocusMap: Record<string, string> = {
-      primary: 'group-focus-within:text-primary',
-      secondary: 'group-focus-within:text-secondary',
-      tertiary: 'group-focus-within:text-tertiary',
-      quaternary: 'group-focus-within:text-quaternary',
-      success: 'group-focus-within:text-success',
-      destructive: 'group-focus-within:text-destructive',
+      primary: "group-focus-within:text-primary",
+      secondary: "group-focus-within:text-secondary",
+      tertiary: "group-focus-within:text-tertiary",
+      quaternary: "group-focus-within:text-quaternary",
+      success: "group-focus-within:text-success",
+      destructive: "group-focus-within:text-destructive",
     };
-    const iconFocusColor = color ? iconFocusMap[color] : '';
+    const iconFocusColor = color ? iconFocusMap[color] : "";
 
     return (
       <div className="relative group">
         {LeftIcon && (
           <LeftIcon
             className={cn(
-              'absolute left-3 top-1/2 -translate-y-1/2 text-muted',
-              iconFocusColor
+              "absolute left-3 top-1/2 -translate-y-1/2 text-muted",
+              iconFocusColor,
             )}
             size={iconSize}
           />
@@ -104,17 +118,18 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           id={inputId}
           type="text"
           ref={ref}
-          aria-invalid={error ? 'true' : undefined}
-          placeholder={label ? ' ' : props.placeholder}
+          aria-invalid={error ? "true" : undefined}
+          placeholder={label ? " " : props.placeholder}
           className={cn(
             inputVariants({
               size,
               error,
               leftIcon: hasLeft,
-              rightIcon: hasRight,
+              rightIcon: hasRight || hasRightButton,
+              rightButton: hasRightButton,
               color,
               className,
-            })
+            }),
           )}
           onChange={handleChange}
           {...props}
@@ -123,9 +138,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <label
             htmlFor={inputId}
             className={cn(
-              'pointer-events-none absolute left-3 top-2 text-xs text-muted-foreground transition-all',
-              'peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2',
-              'peer-focus:top-0 peer-focus:-translate-y-full'
+              "pointer-events-none absolute left-3 top-2 text-xs text-muted-foreground transition-all",
+              "peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2",
+              "peer-focus:top-0 peer-focus:-translate-y-[1.2rem]",
             )}
           >
             {label}
@@ -134,22 +149,34 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         {RightIcon && (
           <RightIcon
             className={cn(
-              'absolute right-3 top-1/2 -translate-y-1/2 text-muted',
-              iconFocusColor
+              "absolute right-3 top-1/2 -translate-y-1/2 text-muted",
+              iconFocusColor,
             )}
             size={iconSize}
           />
         )}
+        {RightButton && (
+          <button
+            type="button"
+            onClick={onRightButtonClick}
+            className={cn(
+              "absolute right-3 top-1/2 -translate-y-1/2 text-muted",
+              iconFocusColor,
+            )}
+          >
+            <RightButton size={iconSize} />
+          </button>
+        )}
         {showCharCount && (
           <span className="absolute bottom-1 right-3 text-xs text-muted-foreground">
             {count}
-            {props.maxLength ? `/${props.maxLength}` : ''}
+            {props.maxLength ? `/${props.maxLength}` : ""}
           </span>
         )}
       </div>
     );
-  }
+  },
 );
-Input.displayName = 'Input';
+Input.displayName = "Input";
 
 export { inputVariants };

--- a/frontend/src/atoms/Input/icons.ts
+++ b/frontend/src/atoms/Input/icons.ts
@@ -17,6 +17,7 @@ import {
   Minus,
   MoreHorizontal,
   Plus,
+  Mic,
   Save,
   Search,
   Settings,
@@ -26,7 +27,7 @@ import {
   Heart,
   Star,
   X,
-} from 'lucide-react';
+} from "lucide-react";
 
 export const iconMap = {
   AlertCircle,
@@ -47,6 +48,7 @@ export const iconMap = {
   Minus,
   MoreHorizontal,
   Plus,
+  Mic,
   Save,
   Search,
   Settings,


### PR DESCRIPTION
## Summary
- tweak floating label position for better visibility
- add `RightButton` prop for interactive icons
- support `Mic` icon option
- show new button and search examples in storybook

## Testing
- `pnpm --filter frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865fa1d64b8832b98310e1389e5f8cd