### PR TITLE
Add Textarea atom component

### DIFF
--- a/frontend/src/atoms/Textarea/Textarea.stories.tsx
+++ b/frontend/src/atoms/Textarea/Textarea.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Textarea, TextareaProps } from "./Textarea";
+
+const meta: Meta<TextareaProps> = {
+  title: "Atoms/Textarea",
+  component: Textarea,
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: "select", options: ["sm", "md", "lg"] },
+    variant: { control: "select", options: ["default", "ghost"] },
+    color: {
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "tertiary",
+        "quaternary",
+        "success",
+        "destructive",
+      ],
+    },
+    disabled: { control: "boolean" },
+    error: { control: "boolean" },
+    placeholder: { control: "text" },
+    label: { control: "text" },
+    showCharCount: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { placeholder: "Enter text" } };
+export const WithError: Story = {
+  args: { placeholder: "Invalid", error: true },
+};
+export const Disabled: Story = {
+  args: { placeholder: "Disabled", disabled: true },
+};
+export const Small: Story = { args: { size: "sm", placeholder: "Small" } };
+export const Large: Story = { args: { size: "lg", placeholder: "Large" } };
+export const WithLabel: Story = {
+  args: { label: "Description", color: "secondary" },
+};
+export const WithCounter: Story = {
+  args: { label: "Notes", showCharCount: true, maxLength: 100, color: "tertiary" },
+};
+export const Ghost: Story = {
+  args: { placeholder: "Ghost variant", variant: "ghost" },
+};

--- a/frontend/src/atoms/Textarea/Textarea.test.tsx
+++ b/frontend/src/atoms/Textarea/Textarea.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Textarea } from './Textarea';
+
+describe('Textarea', () => {
+  it('renders with default classes and rows', () => {
+    render(<Textarea placeholder="text" />);
+    const textarea = screen.getByPlaceholderText('text');
+    expect(textarea).toHaveClass('py-2');
+    expect(textarea).toHaveClass('px-3');
+    expect(textarea).toHaveClass('text-base');
+    expect(textarea).toHaveAttribute('rows', '5');
+  });
+
+  it('renders passed attributes', () => {
+    render(<Textarea value="hello" onChange={() => {}} />);
+    const textarea = screen.getByDisplayValue('hello');
+    expect(textarea).toBeInTheDocument();
+  });
+
+  it('applies size variants', () => {
+    const { rerender } = render(<Textarea size="sm" placeholder="s" />);
+    expect(screen.getByPlaceholderText('s')).toHaveClass('py-1');
+    expect(screen.getByPlaceholderText('s')).toHaveAttribute('rows', '3');
+
+    rerender(<Textarea size="lg" placeholder="l" />);
+    expect(screen.getByPlaceholderText('l')).toHaveClass('py-3');
+    expect(screen.getByPlaceholderText('l')).toHaveAttribute('rows', '8');
+  });
+
+  it('shows error state', () => {
+    render(<Textarea error placeholder="err" />);
+    const textarea = screen.getByPlaceholderText('err');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea.className).toContain('border-destructive');
+  });
+
+  it('supports ghost variant', () => {
+    render(<Textarea variant="ghost" placeholder="g" />);
+    const textarea = screen.getByPlaceholderText('g');
+    expect(textarea.className).toContain('border-none');
+  });
+
+  it('disables the field', () => {
+    render(<Textarea disabled placeholder="d" />);
+    const textarea = screen.getByPlaceholderText('d');
+    expect(textarea).toBeDisabled();
+  });
+
+  it('calls onChange when typing', () => {
+    const handleChange = vi.fn();
+    render(<Textarea onChange={handleChange} />);
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'hi' } });
+    expect(handleChange).toHaveBeenCalled();
+    expect((textarea as HTMLTextAreaElement).value).toBe('hi');
+  });
+
+  it('renders floating label', () => {
+    render(<Textarea label="Notes" id="notes" />);
+    expect(screen.getByText('Notes')).toHaveAttribute('for', 'notes');
+  });
+
+  it('shows character count', () => {
+    render(<Textarea showCharCount label="Comment" maxLength={10} />);
+    const textarea = screen.getByLabelText('Comment');
+    fireEvent.change(textarea, { target: { value: 'abc' } });
+    expect(screen.getByText('3/10')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/atoms/Textarea/Textarea.tsx
+++ b/frontend/src/atoms/Textarea/Textarea.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const textareaVariants = cva(
+  "peer block w-full rounded-md bg-white text-foreground placeholder:text-muted-foreground resize-y focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      size: {
+        sm: "py-1 px-2 text-sm",
+        md: "py-2 px-3 text-base",
+        lg: "py-3 px-4 text-lg",
+      },
+      variant: {
+        default: "border border-border focus:ring-2",
+        ghost: "border-none focus:ring-0",
+      },
+      color: {
+        primary: "border-primary focus:ring-primary",
+        secondary: "border-secondary focus:ring-secondary",
+        tertiary: "border-tertiary focus:ring-tertiary",
+        quaternary: "border-quaternary focus:ring-quaternary",
+        success: "border-success focus:ring-success",
+        destructive: "border-destructive focus:ring-destructive",
+      },
+      error: {
+        true: "border-destructive focus:ring-destructive",
+      },
+    },
+    compoundVariants: [
+      { variant: "ghost", color: "primary", className: "" },
+      { variant: "ghost", color: "secondary", className: "" },
+      { variant: "ghost", color: "tertiary", className: "" },
+      { variant: "ghost", color: "quaternary", className: "" },
+      { variant: "ghost", color: "success", className: "" },
+      { variant: "ghost", color: "destructive", className: "" },
+    ],
+    defaultVariants: {
+      size: "md",
+      variant: "default",
+      color: "primary",
+    },
+  },
+);
+
+export interface TextareaProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "size">,
+    Omit<VariantProps<typeof textareaVariants>, "error"> {
+  label?: string;
+  showCharCount?: boolean;
+  error?: boolean;
+}
+
+const sizeRows: Record<NonNullable<VariantProps<typeof textareaVariants>["size"]>, number> = {
+  sm: 3,
+  md: 5,
+  lg: 8,
+};
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      className,
+      size,
+      variant,
+      color,
+      label,
+      showCharCount,
+      error,
+      onChange,
+      rows,
+      id,
+      ...props
+    },
+    ref,
+  ) => {
+    const [count, setCount] = React.useState(
+      (props.value ?? props.defaultValue ?? "").toString().length,
+    );
+
+    const handleChange: React.ChangeEventHandler<HTMLTextAreaElement> = (e) => {
+      onChange?.(e);
+      if (showCharCount && props.value === undefined) {
+        setCount(e.target.value.length);
+      }
+    };
+
+    const textareaId =
+      id || label ? `${id ?? label?.replace(/\s+/g, "-").toLowerCase()}` : undefined;
+
+    const appliedRows = rows ?? sizeRows[size ?? "md"];
+
+    return (
+      <div className="relative">
+        <textarea
+          id={textareaId}
+          ref={ref}
+          rows={appliedRows}
+          aria-invalid={error ? "true" : undefined}
+          placeholder={label ? " " : props.placeholder}
+          className={cn(textareaVariants({ size, variant, color, error, className }))}
+          onChange={handleChange}
+          {...props}
+        />
+        {label && (
+          <label
+            htmlFor={textareaId}
+            className={cn(
+              "pointer-events-none absolute left-3 top-2 text-xs text-muted-foreground transition-all",
+              "peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2",
+              "peer-focus:top-0 peer-focus:-translate-y-[1.2rem]",
+            )}
+          >
+            {label}
+          </label>
+        )}
+        {showCharCount && (
+          <span className="absolute bottom-1 right-3 text-xs text-muted-foreground">
+            {count}
+            {props.maxLength ? `/${props.maxLength}` : ""}
+          </span>
+        )}
+      </div>
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { textareaVariants };

--- a/frontend/src/atoms/Textarea/index.ts
+++ b/frontend/src/atoms/Textarea/index.ts
@@ -1,0 +1,1 @@
+export * from './Textarea';


### PR DESCRIPTION
## Summary
- implement Textarea atom using CVA with size, color, variant and error states
- add unit tests for Textarea behavior
- add Storybook stories for Textarea
- export Textarea

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666ead59c0832b894b392ac72ce577