### PR TITLE
Add animated auto-resizing to Textarea

### DIFF
--- a/frontend/src/atoms/Textarea/Textarea.stories.tsx
+++ b/frontend/src/atoms/Textarea/Textarea.stories.tsx
@@ -24,6 +24,7 @@ const meta: Meta<TextareaProps> = {
     placeholder: { control: "text" },
     label: { control: "text" },
     showCharCount: { control: "boolean" },
+    autoResize: { control: "boolean" },
   },
 };
 
@@ -47,4 +48,8 @@ export const WithCounter: Story = {
 };
 export const Ghost: Story = {
   args: { placeholder: "Ghost variant", variant: "ghost" },
+};
+
+export const AutoResize: Story = {
+  args: { placeholder: "Auto resize", autoResize: true },
 };

--- a/frontend/src/atoms/Textarea/Textarea.test.tsx
+++ b/frontend/src/atoms/Textarea/Textarea.test.tsx
@@ -67,4 +67,12 @@ describe('Textarea', () => {
     fireEvent.change(textarea, { target: { value: 'abc' } });
     expect(screen.getByText('3/10')).toBeInTheDocument();
   });
+
+  it('auto resizes when typing', () => {
+    render(<Textarea autoResize />);
+    const textarea = screen.getByRole('textbox');
+    Object.defineProperty(textarea, 'scrollHeight', { value: 80, writable: true });
+    fireEvent.change(textarea, { target: { value: 'test' } });
+    expect(textarea.style.height).toBe('80px');
+  });
 });


### PR DESCRIPTION
## Summary
- make Textarea support an `autoResize` prop
- animate height change and disable manual resize when enabled
- showcase the feature in Storybook
- test automatic resizing

## Testing
- `pnpm --filter "./frontend" exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686677a8d6f8832bb271cf3bb05e8b90