### PR TITLE
Add Slider atom

### DIFF
--- a/frontend/src/atoms/Slider/Slider.docs.mdx
+++ b/frontend/src/atoms/Slider/Slider.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Slider } from './Slider';
+
+<Meta title="Atoms/Slider" of={Slider} />
+
+# Slider
+
+The `Slider` component lets users select a numeric value within a range by dragging a thumb along a track.
+
+<Canvas>
+  <Story name="Default">
+    <Slider defaultValue={50} />
+  </Story>
+</Canvas>
+
+<ArgsTable of={Slider} />

--- a/frontend/src/atoms/Slider/Slider.stories.tsx
+++ b/frontend/src/atoms/Slider/Slider.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Slider, SliderProps } from './Slider';
+
+const meta: Meta<SliderProps> = {
+  title: 'Atoms/Slider',
+  component: Slider,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    color: { control: 'select', options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'] },
+    min: { control: 'number' },
+    max: { control: 'number' },
+    step: { control: 'number' },
+    value: { control: 'number' },
+    disabled: { control: 'boolean' },
+    onChange: { action: 'change', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { value: 50 },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-4">
+      <Slider {...args} size="sm" />
+      <Slider {...args} size="md" />
+      <Slider {...args} size="lg" />
+    </div>
+  ),
+  args: { value: 40 },
+};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-4">
+      <Slider {...args} color="primary" />
+      <Slider {...args} color="secondary" />
+      <Slider {...args} color="tertiary" />
+      <Slider {...args} color="quaternary" />
+      <Slider {...args} color="success" />
+    </div>
+  ),
+  args: { value: 30 },
+};
+
+export const Disabled: Story = {
+  args: { value: 60, disabled: true },
+};

--- a/frontend/src/atoms/Slider/Slider.test.tsx
+++ b/frontend/src/atoms/Slider/Slider.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Slider } from './Slider';
+
+describe('Slider', () => {
+  it('renders with default attributes', () => {
+    render(<Slider min={0} max={100} defaultValue={50} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('min', '0');
+    expect(slider).toHaveAttribute('max', '100');
+    expect(slider).toHaveValue('50');
+  });
+
+  it('applies size variants', () => {
+    const { rerender } = render(<Slider size="sm" />);
+    const slider = screen.getByRole('slider');
+    expect(slider.className).toContain('slider-sm');
+
+    rerender(<Slider size="lg" />);
+    expect(slider.className).toContain('slider-lg');
+  });
+
+  it('calls onChange when value changes', () => {
+    const handleChange = vi.fn();
+    render(<Slider onChange={handleChange} />);
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '30' } });
+    expect(handleChange).toHaveBeenCalled();
+    expect(slider).toHaveValue('30');
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    render(<Slider disabled />);
+    expect(screen.getByRole('slider')).toBeDisabled();
+  });
+});

--- a/frontend/src/atoms/Slider/Slider.tsx
+++ b/frontend/src/atoms/Slider/Slider.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const sliderVariants = cva("slider", {
+  variants: {
+    size: {
+      sm: "slider-sm",
+      md: "slider-md",
+      lg: "slider-lg",
+    },
+    color: {
+      primary: "slider-primary",
+      secondary: "slider-secondary",
+      tertiary: "slider-tertiary",
+      quaternary: "slider-quaternary",
+      success: "slider-success",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+    color: "primary",
+  },
+});
+
+export interface SliderProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+    VariantProps<typeof sliderVariants> {}
+
+export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  (
+    {
+      className,
+      size,
+      color,
+      min = 0,
+      max = 100,
+      step = 1,
+      value,
+      defaultValue,
+      onChange,
+      ...props
+    },
+    ref,
+  ) => {
+    const [internal, setInternal] = React.useState(
+      Number(value ?? defaultValue ?? min),
+    );
+
+    React.useEffect(() => {
+      if (value !== undefined) {
+        setInternal(Number(value));
+      }
+    }, [value]);
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      if (value === undefined) {
+        setInternal(Number(e.target.value));
+      }
+      onChange?.(e);
+    };
+
+    const percentage =
+      ((internal - Number(min)) / (Number(max) - Number(min))) * 100;
+
+    return (
+      <input
+        type="range"
+        role="slider"
+        ref={ref}
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        defaultValue={defaultValue}
+        onChange={handleChange}
+        className={cn(sliderVariants({ size, color, className }))}
+        style={{
+          // @ts-ignore -- CSS variable for background size
+          "--slider-percentage": `${percentage}%`,
+        }}
+        {...props}
+      />
+    );
+  },
+);
+Slider.displayName = "Slider";
+
+export { sliderVariants };

--- a/frontend/src/atoms/Slider/index.ts
+++ b/frontend/src/atoms/Slider/index.ts
@@ -1,0 +1,1 @@
+export * from './Slider';

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -127,3 +127,53 @@
     border: 1px solid rgba(255, 255, 255, 0.18);
   }
 }
+
+@layer components {
+  .slider {
+    @apply appearance-none w-full cursor-pointer rounded-full bg-muted disabled:opacity-50 disabled:cursor-not-allowed;
+    height: var(--slider-track-height, 0.375rem);
+    background-image: linear-gradient(hsl(var(--slider-color, var(--primary))), hsl(var(--slider-color, var(--primary))));
+    background-repeat: no-repeat;
+    background-size: var(--slider-percentage, 0%) 100%;
+  }
+  .slider::-webkit-slider-thumb {
+    @apply appearance-none rounded-full border-none;
+    height: var(--slider-thumb-size, 1rem);
+    width: var(--slider-thumb-size, 1rem);
+    background-color: hsl(var(--slider-color, var(--primary)));
+    margin-top: calc((var(--slider-track-height, 0.375rem) - var(--slider-thumb-size, 1rem)) / 2);
+  }
+  .slider::-moz-range-thumb {
+    @apply appearance-none rounded-full border-none;
+    height: var(--slider-thumb-size, 1rem);
+    width: var(--slider-thumb-size, 1rem);
+    background-color: hsl(var(--slider-color, var(--primary)));
+  }
+  .slider-sm {
+    --slider-track-height: 0.25rem;
+    --slider-thumb-size: 0.75rem;
+  }
+  .slider-md {
+    --slider-track-height: 0.375rem;
+    --slider-thumb-size: 1rem;
+  }
+  .slider-lg {
+    --slider-track-height: 0.5rem;
+    --slider-thumb-size: 1.25rem;
+  }
+  .slider-primary {
+    --slider-color: var(--primary);
+  }
+  .slider-secondary {
+    --slider-color: var(--secondary);
+  }
+  .slider-tertiary {
+    --slider-color: var(--tertiary);
+  }
+  .slider-quaternary {
+    --slider-color: var(--quaternary);
+  }
+  .slider-success {
+    --slider-color: var(--success);
+  }
+}


### PR DESCRIPTION
## Summary
- implement Slider atom with size and color variants
- add Storybook stories and docs
- add unit tests
- define slider styles in global.css

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_686c8687fc00832bbe01c44a6f0da233