### PR TITLE
Add Heading atom

### DIFF
--- a/frontend/src/atoms/Heading/Heading.docs.mdx
+++ b/frontend/src/atoms/Heading/Heading.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Heading } from './Heading';
+
+<Meta title="Atoms/Heading" of={Heading} />
+
+# Heading
+
+The `Heading` component renders semantic heading elements with the design system's typography. Use the `level` prop to choose the heading size.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <Heading level={1}>Heading 1</Heading>
+      <Heading level={2}>Heading 2</Heading>
+      <Heading level={3}>Heading 3</Heading>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Heading} />

--- a/frontend/src/atoms/Heading/Heading.stories.tsx
+++ b/frontend/src/atoms/Heading/Heading.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Heading, HeadingProps } from './Heading';
+
+const meta: Meta<HeadingProps> = {
+  title: 'Atoms/Heading',
+  component: Heading,
+  tags: ['autodocs'],
+  argTypes: {
+    level: { control: 'number', options: [1, 2, 3, 4, 5, 6] },
+    align: { control: 'select', options: ['left', 'center', 'right'] },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    as: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { level: 1, children: 'Heading 1' },
+};
+
+export const Levels: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <Heading {...args} level={1}>Heading 1</Heading>
+      <Heading {...args} level={2}>Heading 2</Heading>
+      <Heading {...args} level={3}>Heading 3</Heading>
+      <Heading {...args} level={4}>Heading 4</Heading>
+      <Heading {...args} level={5}>Heading 5</Heading>
+      <Heading {...args} level={6}>Heading 6</Heading>
+    </div>
+  ),
+  args: {},
+};
+
+export const Center: Story = {
+  args: { level: 2, align: 'center', children: 'Centered Heading' },
+};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <Heading {...args} color="primary">Primary</Heading>
+      <Heading {...args} color="secondary">Secondary</Heading>
+      <Heading {...args} color="tertiary">Tertiary</Heading>
+      <Heading {...args} color="quaternary">Quaternary</Heading>
+      <Heading {...args} color="success">Success</Heading>
+    </div>
+  ),
+  args: { level: 3 },
+};

--- a/frontend/src/atoms/Heading/Heading.test.tsx
+++ b/frontend/src/atoms/Heading/Heading.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Heading } from './Heading';
+
+describe('Heading', () => {
+  it('renders the correct level element', () => {
+    render(<Heading level={3}>Title</Heading>);
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('allows overriding the element with as prop', () => {
+    render(<Heading level={2} as="h1">Text</Heading>);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading.tagName).toBe('H1');
+  });
+
+  it('applies variant classes', () => {
+    render(
+      <Heading level={4} align="center" color="secondary">Content</Heading>
+    );
+    const heading = screen.getByRole('heading', { level: 4 });
+    expect(heading.className).toContain('text-center');
+    expect(heading.className).toContain('text-secondary');
+  });
+
+  it('merges additional classes', () => {
+    render(<Heading className="mb-2">Hello</Heading>);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveClass('mb-2');
+  });
+});

--- a/frontend/src/atoms/Heading/Heading.tsx
+++ b/frontend/src/atoms/Heading/Heading.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const headingVariants = cva('', {
+  variants: {
+    level: {
+      '1': 'font-heading text-5xl font-bold tracking-tight',
+      '2': 'font-heading text-4xl font-semibold tracking-tight',
+      '3': 'font-heading text-3xl font-semibold tracking-tight',
+      '4': 'font-heading text-2xl font-semibold tracking-tight',
+      '5': 'font-heading text-xl font-semibold tracking-tight',
+      '6': 'font-heading text-lg font-semibold tracking-tight',
+    },
+    align: {
+      left: 'text-left',
+      center: 'text-center',
+      right: 'text-right',
+    },
+    color: {
+      primary: 'text-primary',
+      secondary: 'text-secondary',
+      tertiary: 'text-tertiary',
+      quaternary: 'text-quaternary',
+      success: 'text-success',
+    },
+  },
+  defaultVariants: {
+    level: '1',
+    align: 'left',
+    color: 'primary',
+  },
+});
+
+export interface HeadingProps
+  extends React.HTMLAttributes<HTMLHeadingElement>,
+    Omit<VariantProps<typeof headingVariants>, 'level'> {
+  /** Visual and semantic level (1-6). */
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  /** Override the rendered element. */
+  as?: React.ElementType;
+}
+
+const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
+  ({ className, level = 1, align, color, as: Tag, ...props }, ref) => {
+    const Component = Tag || (`h${level}` as keyof JSX.IntrinsicElements);
+    const variantLevel = String(level) as VariantProps<typeof headingVariants>['level'];
+    return (
+      <Component
+        ref={ref}
+        className={cn(headingVariants({ level: variantLevel, align, color }), className)}
+        {...props}
+      />
+    );
+  },
+);
+Heading.displayName = 'Heading';
+
+export { Heading, headingVariants };

--- a/frontend/src/atoms/Heading/index.ts
+++ b/frontend/src/atoms/Heading/index.ts
@@ -1,0 +1,1 @@
+export * from './Heading';


### PR DESCRIPTION
## Summary
- add Heading atom with customizable level, alignment and color
- document Heading in Storybook with docs page
- add Storybook examples for Heading
- include unit tests for Heading

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_686d198b28b8832b90de5f9449e05a31