### PR TITLE
Add Text atom

### DIFF
--- a/frontend/src/atoms/Text/Text.docs.mdx
+++ b/frontend/src/atoms/Text/Text.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Text } from './Text';
+
+<Meta title="Atoms/Text" of={Text} />
+
+# Text
+
+The `Text` component provides consistent styling for paragraph or inline text. Use the `size`, `weight`, and `color` props to control its appearance.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <Text>Lorem ipsum dolor sit amet.</Text>
+      <Text size="sm" muted>Small muted text</Text>
+      <Text size="lg" weight="semibold">Large semibold text</Text>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Text} />

--- a/frontend/src/atoms/Text/Text.stories.tsx
+++ b/frontend/src/atoms/Text/Text.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Text, TextProps } from './Text';
+
+const meta: Meta<TextProps> = {
+  title: 'Atoms/Text',
+  component: Text,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    weight: { control: 'select', options: ['normal', 'semibold', 'bold'] },
+    color: {
+      control: 'select',
+      options: [undefined, 'primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    muted: { control: 'boolean' },
+    as: { control: 'text' },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <Text {...args} size="sm">Small text</Text>
+      <Text {...args} size="md">Default text</Text>
+      <Text {...args} size="lg">Large text</Text>
+    </div>
+  ),
+  args: {},
+};
+
+export const Muted: Story = {
+  args: { children: 'Secondary information', muted: true, size: 'sm' },
+};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <Text {...args} color="primary">Primary</Text>
+      <Text {...args} color="secondary">Secondary</Text>
+      <Text {...args} color="tertiary">Tertiary</Text>
+      <Text {...args} color="quaternary">Quaternary</Text>
+      <Text {...args} color="success">Success</Text>
+    </div>
+  ),
+  args: {},
+};

--- a/frontend/src/atoms/Text/Text.test.tsx
+++ b/frontend/src/atoms/Text/Text.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Text } from './Text';
+
+describe('Text', () => {
+  it('renders the provided content', () => {
+    render(<Text>Hello</Text>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('uses a <p> by default', () => {
+    render(<Text>Paragraph</Text>);
+    const element = screen.getByText('Paragraph');
+    expect(element.tagName).toBe('P');
+  });
+
+  it('applies size variants', () => {
+    const { rerender } = render(<Text size="sm">small</Text>);
+    expect(screen.getByText('small')).toHaveClass('text-sm');
+
+    rerender(<Text size="lg">large</Text>);
+    expect(screen.getByText('large')).toHaveClass('text-lg');
+  });
+
+  it('applies muted style', () => {
+    render(<Text muted>Muted</Text>);
+    expect(screen.getByText('Muted')).toHaveClass('text-muted-foreground');
+  });
+
+  it('allows overriding the element with as prop', () => {
+    render(<Text as="span">Inline</Text>);
+    const element = screen.getByText('Inline');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges additional class names', () => {
+    render(<Text className="mb-2">Class</Text>);
+    expect(screen.getByText('Class')).toHaveClass('mb-2');
+  });
+});

--- a/frontend/src/atoms/Text/Text.tsx
+++ b/frontend/src/atoms/Text/Text.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const textVariants = cva('font-sans', {
+  variants: {
+    size: {
+      sm: 'text-sm',
+      md: 'text-base',
+      lg: 'text-lg',
+    },
+    weight: {
+      normal: 'font-normal',
+      semibold: 'font-semibold',
+      bold: 'font-bold',
+    },
+    color: {
+      primary: 'text-primary',
+      secondary: 'text-secondary',
+      tertiary: 'text-tertiary',
+      quaternary: 'text-quaternary',
+      success: 'text-success',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    weight: 'normal',
+  },
+});
+
+export interface TextProps
+  extends React.HTMLAttributes<HTMLElement>,
+    VariantProps<typeof textVariants> {
+  /** Render as a different element */
+  as?: React.ElementType;
+  /** Apply muted foreground color */
+  muted?: boolean;
+}
+
+export const Text = React.forwardRef<HTMLElement, TextProps>(
+  (
+    { as: Tag = 'p', className, size, weight, color, muted, ...props },
+    ref,
+  ) => {
+    const Component = Tag as keyof JSX.IntrinsicElements;
+    return (
+      <Component
+        ref={ref}
+        className={cn(
+          textVariants({ size, weight, color }),
+          muted && 'text-muted-foreground',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Text.displayName = 'Text';
+
+export { textVariants };

--- a/frontend/src/atoms/Text/index.ts
+++ b/frontend/src/atoms/Text/index.ts
@@ -1,0 +1,1 @@
+export * from './Text';


### PR DESCRIPTION
## Summary
- add a new `Text` atom component with size, weight and color variants
- document the `Text` component in Storybook
- provide Storybook stories for examples and variants
- test the `Text` component

## Testing
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686d1d2679bc832bba1d756ece2987ef