### PR TITLE
Improve text and heading typography

### DIFF
--- a/frontend/src/atoms/Heading/Heading.tsx
+++ b/frontend/src/atoms/Heading/Heading.tsx
@@ -3,15 +3,15 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
-const headingVariants = cva('', {
+const headingVariants = cva('font-heading', {
   variants: {
     level: {
-      '1': 'font-heading text-5xl font-bold tracking-tight',
-      '2': 'font-heading text-4xl font-semibold tracking-tight',
-      '3': 'font-heading text-3xl font-semibold tracking-tight',
-      '4': 'font-heading text-2xl font-semibold tracking-tight',
-      '5': 'font-heading text-xl font-semibold tracking-tight',
-      '6': 'font-heading text-lg font-semibold tracking-tight',
+      '1': 'text-5xl font-bold tracking-tight',
+      '2': 'text-4xl font-semibold tracking-tight',
+      '3': 'text-3xl font-semibold tracking-tight',
+      '4': 'text-2xl font-semibold tracking-tight',
+      '5': 'text-xl font-semibold tracking-tight',
+      '6': 'text-lg font-semibold tracking-tight',
     },
     align: {
       left: 'text-left',

--- a/frontend/src/atoms/Text/Text.test.tsx
+++ b/frontend/src/atoms/Text/Text.test.tsx
@@ -19,7 +19,15 @@ describe('Text', () => {
     expect(screen.getByText('small')).toHaveClass('text-sm');
 
     rerender(<Text size="lg">large</Text>);
-    expect(screen.getByText('large')).toHaveClass('text-lg');
+    expect(screen.getByText('large')).toHaveClass('text-xl');
+  });
+
+  it('applies weight variants', () => {
+    const { rerender } = render(<Text weight="normal">w1</Text>);
+    expect(screen.getByText('w1')).toHaveClass('font-normal');
+
+    rerender(<Text weight="bold">w2</Text>);
+    expect(screen.getByText('w2')).toHaveClass('font-bold');
   });
 
   it('applies muted style', () => {

--- a/frontend/src/atoms/Text/Text.tsx
+++ b/frontend/src/atoms/Text/Text.tsx
@@ -6,8 +6,8 @@ const textVariants = cva('font-sans', {
   variants: {
     size: {
       sm: 'text-sm',
-      md: 'text-base',
-      lg: 'text-lg',
+      md: 'text-lg',
+      lg: 'text-xl',
     },
     weight: {
       normal: 'font-normal',


### PR DESCRIPTION
## Summary
- adjust heading base font to use theme's heading font
- increase text size scale for better readability
- test text weight variants

## Testing
- `pnpm --filter ./frontend test` *(fails: vitest not found)*
- `pnpm install` *(fails: Cannot use 'in' operator to search for 'errno')*

------
https://chatgpt.com/codex/tasks/task_e_686d351cca5c832b8488ad409e82d831