### PR TITLE
Fix Text atom font usage

### DIFF
--- a/frontend/src/atoms/Text/Text.stories.tsx
+++ b/frontend/src/atoms/Text/Text.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<TextProps> = {
   tags: ['autodocs'],
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
-    weight: { control: 'select', options: ['normal', 'semibold', 'bold'] },
+    weight: { control: 'select', options: ['normal', 'medium', 'semibold', 'bold'] },
     color: {
       control: 'select',
       options: [undefined, 'primary', 'secondary', 'tertiary', 'quaternary', 'success'],
@@ -58,6 +58,7 @@ export const Weights: Story = {
   render: (args) => (
     <div className="space-y-2">
       <Text {...args} weight="normal">Normal weight</Text>
+      <Text {...args} weight="medium">Medium weight</Text>
       <Text {...args} weight="semibold">Semibold weight</Text>
       <Text {...args} weight="bold">Bold weight</Text>
     </div>

--- a/frontend/src/atoms/Text/Text.test.tsx
+++ b/frontend/src/atoms/Text/Text.test.tsx
@@ -26,8 +26,11 @@ describe('Text', () => {
     const { rerender } = render(<Text weight="normal">w1</Text>);
     expect(screen.getByText('w1')).toHaveClass('font-normal');
 
-    rerender(<Text weight="bold">w2</Text>);
-    expect(screen.getByText('w2')).toHaveClass('font-bold');
+    rerender(<Text weight="medium">w2</Text>);
+    expect(screen.getByText('w2')).toHaveClass('font-medium');
+
+    rerender(<Text weight="bold">w3</Text>);
+    expect(screen.getByText('w3')).toHaveClass('font-bold');
   });
 
   it('applies muted style', () => {

--- a/frontend/src/atoms/Text/Text.tsx
+++ b/frontend/src/atoms/Text/Text.tsx
@@ -11,6 +11,7 @@ const textVariants = cva('font-sans', {
     },
     weight: {
       normal: 'font-normal',
+      medium: 'font-medium',
       semibold: 'font-semibold',
       bold: 'font-bold',
     },

--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -5,6 +5,7 @@ export default {
   darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
+    fontFamily: tokens.fontFamily,
     extend: {
       colors: {
         ...tokens.colors.neutral,
@@ -45,7 +46,6 @@ export default {
       },
       borderRadius: tokens.radius,
       boxShadow: tokens.shadow,
-      fontFamily: tokens.fontFamily,
     },
   },
   plugins: [require('@tailwindcss/forms')],


### PR DESCRIPTION
## Summary
- use `tokens.fontFamily` directly in Tailwind config so body font loads
- add `medium` font weight variant to Text
- support new weight in stories and tests

## Testing
- `pnpm --filter ./frontend exec vitest run` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_686ed0f08b48832b85bc547f0b88d563