### PR TITLE
Add Link atom

### DIFF
--- a/frontend/src/atoms/Link/Link.docs.mdx
+++ b/frontend/src/atoms/Link/Link.docs.mdx
@@ -1,0 +1,22 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Link } from './Link';
+
+<Meta title="Atoms/Link" of={Link} />
+
+# Link
+
+The `Link` component provides styled anchor elements consistent with the design system. Use the `color` and `underline` variants to control its appearance. Set `isExternal` to open the link in a new tab.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <Link href="#">Default Link</Link>
+      <br />
+      <Link href="#" underline={false}>No underline</Link>
+      <br />
+      <Link href="https://example.com" isExternal>External Link</Link>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Link} />

--- a/frontend/src/atoms/Link/Link.stories.tsx
+++ b/frontend/src/atoms/Link/Link.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Link, LinkProps } from './Link';
+
+const meta: Meta<LinkProps> = {
+  title: 'Atoms/Link',
+  component: Link,
+  tags: ['autodocs'],
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    underline: { control: 'boolean' },
+    isExternal: { control: 'boolean' },
+    href: { control: 'text' },
+    target: { table: { disable: true } },
+    rel: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { href: '#', children: 'Default Link' },
+};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div className="space-x-2">
+      <Link {...args} color="primary">Primary</Link>
+      <Link {...args} color="secondary">Secondary</Link>
+      <Link {...args} color="tertiary">Tertiary</Link>
+      <Link {...args} color="quaternary">Quaternary</Link>
+      <Link {...args} color="success">Success</Link>
+    </div>
+  ),
+  args: { href: '#', underline: true },
+};
+
+export const NoUnderline: Story = {
+  args: { href: '#', underline: false, children: 'No underline' },
+};
+
+export const External: Story = {
+  args: {
+    href: 'https://example.com',
+    isExternal: true,
+    children: 'External link',
+  },
+};

--- a/frontend/src/atoms/Link/Link.test.tsx
+++ b/frontend/src/atoms/Link/Link.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Link } from './Link';
+
+describe('Link', () => {
+  it('renders anchor with href and children', () => {
+    render(<Link href="/home">Home</Link>);
+    const link = screen.getByRole('link', { name: /home/i });
+    expect(link).toHaveAttribute('href', '/home');
+  });
+
+  it('applies color variant', () => {
+    render(<Link href="#" color="tertiary">Tertiary</Link>);
+    const link = screen.getByRole('link', { name: /tertiary/i });
+    expect(link.className).toContain('text-tertiary');
+  });
+
+  it('removes underline when underline is false', () => {
+    render(<Link href="#" underline={false}>No Underline</Link>);
+    const link = screen.getByRole('link', { name: /no underline/i });
+    expect(link.className).toContain('no-underline');
+  });
+
+  it('adds target and rel for external links', () => {
+    render(<Link href="https://example.com" isExternal>External</Link>);
+    const link = screen.getByRole('link', { name: /external/i });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/frontend/src/atoms/Link/Link.tsx
+++ b/frontend/src/atoms/Link/Link.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const linkVariants = cva(
+  'text-sm font-medium underline-offset-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-offset-background',
+  {
+    variants: {
+      color: {
+        primary: 'text-primary hover:text-primary/80',
+        secondary: 'text-secondary hover:text-secondary/80',
+        tertiary: 'text-tertiary hover:text-tertiary/80',
+        quaternary: 'text-quaternary hover:text-quaternary/80',
+        success: 'text-success hover:text-success/80',
+      },
+      underline: {
+        true: 'underline',
+        false: 'no-underline',
+      },
+    },
+    defaultVariants: {
+      color: 'secondary',
+      underline: true,
+    },
+  },
+);
+
+export interface LinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    VariantProps<typeof linkVariants> {
+  /** If true, the link opens in a new tab */
+  isExternal?: boolean;
+}
+
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ className, color, underline, isExternal, target, rel, ...props }, ref) => {
+    return (
+      <a
+        ref={ref}
+        className={cn(linkVariants({ color, underline }), className)}
+        target={isExternal ? '_blank' : target}
+        rel={isExternal ? 'noopener noreferrer' : rel}
+        {...props}
+      />
+    );
+  },
+);
+Link.displayName = 'Link';
+
+export { Link, linkVariants };

--- a/frontend/src/atoms/Link/index.ts
+++ b/frontend/src/atoms/Link/index.ts
@@ -1,0 +1,1 @@
+export * from './Link';


### PR DESCRIPTION
## Summary
- add Link atom with color and underline variants, and external link option
- document Link atom in Storybook and test its behavior

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686ee4ef4410832baf8e163119461fed