### PR TITLE
Add hover underline option for Link atom

### DIFF
--- a/frontend/src/atoms/Link/Link.docs.mdx
+++ b/frontend/src/atoms/Link/Link.docs.mdx
@@ -5,14 +5,16 @@ import { Link } from './Link';
 
 # Link
 
-The `Link` component provides styled anchor elements consistent with the design system. Use the `color` and `underline` variants to control its appearance. Set `isExternal` to open the link in a new tab.
+The `Link` component provides styled anchor elements consistent with the design system. Use the `color` variant to control its palette and the `underline` variant (`"always"`, `"hover"`, or `"none"`) to choose how the underline appears. Set `isExternal` to open the link in a new tab.
 
 <Canvas>
   <Story name="Examples">
     <>
       <Link href="#">Default Link</Link>
       <br />
-      <Link href="#" underline={false}>No underline</Link>
+      <Link href="#" underline="none">No underline</Link>
+      <br />
+      <Link href="#" underline="hover">Underline on hover</Link>
       <br />
       <Link href="https://example.com" isExternal>External Link</Link>
     </>

--- a/frontend/src/atoms/Link/Link.stories.tsx
+++ b/frontend/src/atoms/Link/Link.stories.tsx
@@ -10,7 +10,10 @@ const meta: Meta<LinkProps> = {
       control: 'select',
       options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
     },
-    underline: { control: 'boolean' },
+    underline: {
+      control: 'select',
+      options: ['always', 'hover', 'none'],
+    },
     isExternal: { control: 'boolean' },
     href: { control: 'text' },
     target: { table: { disable: true } },
@@ -35,11 +38,15 @@ export const Colors: Story = {
       <Link {...args} color="success">Success</Link>
     </div>
   ),
-  args: { href: '#', underline: true },
+  args: { href: '#', underline: 'always' },
 };
 
 export const NoUnderline: Story = {
-  args: { href: '#', underline: false, children: 'No underline' },
+  args: { href: '#', underline: 'none', children: 'No underline' },
+};
+
+export const HoverUnderline: Story = {
+  args: { href: '#', underline: 'hover', children: 'Underline on hover' },
 };
 
 export const External: Story = {

--- a/frontend/src/atoms/Link/Link.test.tsx
+++ b/frontend/src/atoms/Link/Link.test.tsx
@@ -15,10 +15,16 @@ describe('Link', () => {
     expect(link.className).toContain('text-tertiary');
   });
 
-  it('removes underline when underline is false', () => {
-    render(<Link href="#" underline={false}>No Underline</Link>);
+  it('removes underline when underline is "none"', () => {
+    render(<Link href="#" underline="none">No Underline</Link>);
     const link = screen.getByRole('link', { name: /no underline/i });
     expect(link.className).toContain('no-underline');
+  });
+
+  it('applies hover underline when underline is "hover"', () => {
+    render(<Link href="#" underline="hover">Hover</Link>);
+    const link = screen.getByRole('link', { name: /hover/i });
+    expect(link.className).toContain('hover:underline');
   });
 
   it('adds target and rel for external links', () => {

--- a/frontend/src/atoms/Link/Link.tsx
+++ b/frontend/src/atoms/Link/Link.tsx
@@ -14,13 +14,14 @@ const linkVariants = cva(
         success: 'text-success hover:text-success/80',
       },
       underline: {
-        true: 'underline',
-        false: 'no-underline',
+        always: 'underline',
+        hover: 'hover:underline',
+        none: 'no-underline',
       },
     },
     defaultVariants: {
       color: 'secondary',
-      underline: true,
+      underline: 'always',
     },
   },
 );


### PR DESCRIPTION
## Summary
- allow `underline` variant to accept `always`, `hover` and `none`
- document new options in Link docs
- update Storybook stories for Link
- extend tests for new underline behaviour

## Testing
- `pnpm --filter erp_system test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687056e0b630832b8b047f81f3dafe99