### PR TITLE
Fix link underline styling

### DIFF
--- a/frontend/src/atoms/Link/Link.docs.mdx
+++ b/frontend/src/atoms/Link/Link.docs.mdx
@@ -5,16 +5,12 @@ import { Link } from './Link';
 
 # Link
 
-The `Link` component provides styled anchor elements consistent with the design system. Use the `color` variant to control its palette and the `underline` variant (`"always"`, `"hover"`, or `"none"`) to choose how the underline appears. Set `isExternal` to open the link in a new tab.
+The `Link` component provides styled anchor elements consistent with the design system. Use the `color` variant to control its palette. Links are underlined by default. Set `isExternal` to open the link in a new tab.
 
 <Canvas>
   <Story name="Examples">
     <>
       <Link href="#">Default Link</Link>
-      <br />
-      <Link href="#" underline="none">No underline</Link>
-      <br />
-      <Link href="#" underline="hover">Underline on hover</Link>
       <br />
       <Link href="https://example.com" isExternal>External Link</Link>
     </>

--- a/frontend/src/atoms/Link/Link.stories.tsx
+++ b/frontend/src/atoms/Link/Link.stories.tsx
@@ -10,10 +10,6 @@ const meta: Meta<LinkProps> = {
       control: 'select',
       options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
     },
-    underline: {
-      control: 'select',
-      options: ['always', 'hover', 'none'],
-    },
     isExternal: { control: 'boolean' },
     href: { control: 'text' },
     target: { table: { disable: true } },
@@ -38,16 +34,9 @@ export const Colors: Story = {
       <Link {...args} color="success">Success</Link>
     </div>
   ),
-  args: { href: '#', underline: 'always' },
+  args: { href: '#' },
 };
 
-export const NoUnderline: Story = {
-  args: { href: '#', underline: 'none', children: 'No underline' },
-};
-
-export const HoverUnderline: Story = {
-  args: { href: '#', underline: 'hover', children: 'Underline on hover' },
-};
 
 export const External: Story = {
   args: {

--- a/frontend/src/atoms/Link/Link.test.tsx
+++ b/frontend/src/atoms/Link/Link.test.tsx
@@ -15,16 +15,10 @@ describe('Link', () => {
     expect(link.className).toContain('text-tertiary');
   });
 
-  it('removes underline when underline is "none"', () => {
-    render(<Link href="#" underline="none">No Underline</Link>);
-    const link = screen.getByRole('link', { name: /no underline/i });
-    expect(link.className).toContain('no-underline');
-  });
-
-  it('applies hover underline when underline is "hover"', () => {
-    render(<Link href="#" underline="hover">Hover</Link>);
-    const link = screen.getByRole('link', { name: /hover/i });
-    expect(link.className).toContain('hover:underline');
+  it('has underline by default', () => {
+    render(<Link href="#">Default</Link>);
+    const link = screen.getByRole('link', { name: /default/i });
+    expect(link.className).toContain('underline');
   });
 
   it('adds target and rel for external links', () => {

--- a/frontend/src/atoms/Link/Link.tsx
+++ b/frontend/src/atoms/Link/Link.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const linkVariants = cva(
-  'text-sm font-medium underline-offset-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-offset-background',
+  'text-sm font-medium underline underline-offset-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-offset-background',
   {
     variants: {
       color: {
@@ -13,15 +13,9 @@ const linkVariants = cva(
         quaternary: 'text-quaternary hover:text-quaternary/80',
         success: 'text-success hover:text-success/80',
       },
-      underline: {
-        always: 'underline',
-        hover: 'hover:underline',
-        none: 'no-underline',
-      },
     },
     defaultVariants: {
       color: 'secondary',
-      underline: 'always',
     },
   },
 );
@@ -34,11 +28,11 @@ export interface LinkProps
 }
 
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ className, color, underline, isExternal, target, rel, ...props }, ref) => {
+  ({ className, color, isExternal, target, rel, ...props }, ref) => {
     return (
       <a
         ref={ref}
-        className={cn(linkVariants({ color, underline }), className)}
+        className={cn(linkVariants({ color }), className)}
         target={isExternal ? '_blank' : target}
         rel={isExternal ? 'noopener noreferrer' : rel}
         {...props}


### PR DESCRIPTION
## Summary
- update Link component to always underline
- revise Link stories, docs and tests accordingly

## Testing
- `pnpm -r exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6870f8bd1a9c832bad83705e109cc68c