### PR TITLE
Add Divider atom

### DIFF
--- a/frontend/src/atoms/Divider/Divider.docs.mdx
+++ b/frontend/src/atoms/Divider/Divider.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Divider } from './Divider';
+
+<Meta title="Atoms/Divider" of={Divider} />
+
+# Divider
+
+Use the `Divider` component to visually separate content. It supports horizontal and vertical orientations as well as configurable spacing and color.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <p>Section 1</p>
+      <Divider />
+      <p>Section 2</p>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Divider} />

--- a/frontend/src/atoms/Divider/Divider.stories.tsx
+++ b/frontend/src/atoms/Divider/Divider.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Divider, DividerProps } from './Divider';
+
+const meta: Meta<DividerProps> = {
+  title: 'Atoms/Divider',
+  component: Divider,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: { control: 'select', options: ['horizontal', 'vertical'] },
+    spacing: { control: 'select', options: ['none', 'sm', 'md', 'lg'] },
+    color: {
+      control: 'select',
+      options: ['default', 'primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+    },
+    className: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  args: {},
+  render: (args) => (
+    <div>
+      <p>First section</p>
+      <Divider {...args} />
+      <p>Second section</p>
+    </div>
+  ),
+};
+
+export const Vertical: Story = {
+  args: { orientation: 'vertical', spacing: 'md' },
+  render: (args) => (
+    <div className="flex items-center">
+      <span>Left</span>
+      <Divider {...args} />
+      <span>Right</span>
+    </div>
+  ),
+};

--- a/frontend/src/atoms/Divider/Divider.test.tsx
+++ b/frontend/src/atoms/Divider/Divider.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Divider } from './Divider';
+
+describe('Divider', () => {
+  it('renders an hr by default', () => {
+    render(<Divider />);
+    const separator = screen.getByRole('separator');
+    expect(separator.tagName).toBe('HR');
+  });
+
+  it('renders vertical orientation', () => {
+    render(<Divider orientation="vertical" data-testid="v" />);
+    const separator = screen.getByTestId('v');
+    expect(separator.tagName).toBe('DIV');
+    expect(separator).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  it('applies spacing variants', () => {
+    const { rerender } = render(<Divider spacing="sm" />);
+    let separator = screen.getByRole('separator');
+    expect(separator.className).toContain('my-1');
+    rerender(<Divider spacing="lg" />);
+    separator = screen.getByRole('separator');
+    expect(separator.className).toContain('my-6');
+  });
+
+  it('applies color variants', () => {
+    render(<Divider color="primary" />);
+    const separator = screen.getByRole('separator');
+    expect(separator.className).toContain('border-primary');
+  });
+
+  it('accepts custom className', () => {
+    render(<Divider className="border-2" />);
+    const separator = screen.getByRole('separator');
+    expect(separator).toHaveClass('border-2');
+  });
+});

--- a/frontend/src/atoms/Divider/Divider.tsx
+++ b/frontend/src/atoms/Divider/Divider.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const dividerVariants = cva('', {
+  variants: {
+    orientation: {
+      horizontal: 'w-full border-t',
+      vertical: 'h-full border-l self-stretch',
+    },
+    spacing: {
+      none: '',
+      sm: '',
+      md: '',
+      lg: '',
+    },
+    color: {
+      default: 'border-border',
+      primary: 'border-primary',
+      secondary: 'border-secondary',
+      tertiary: 'border-tertiary',
+      quaternary: 'border-quaternary',
+      success: 'border-success',
+      destructive: 'border-destructive',
+    },
+  },
+  compoundVariants: [
+    { orientation: 'horizontal', spacing: 'sm', className: 'my-1' },
+    { orientation: 'horizontal', spacing: 'md', className: 'my-3' },
+    { orientation: 'horizontal', spacing: 'lg', className: 'my-6' },
+    { orientation: 'vertical', spacing: 'sm', className: 'mx-1' },
+    { orientation: 'vertical', spacing: 'md', className: 'mx-3' },
+    { orientation: 'vertical', spacing: 'lg', className: 'mx-6' },
+  ],
+  defaultVariants: {
+    orientation: 'horizontal',
+    spacing: 'md',
+    color: 'default',
+  },
+});
+
+export interface DividerProps
+  extends React.HTMLAttributes<HTMLDivElement | HTMLHRElement>,
+    VariantProps<typeof dividerVariants> {}
+
+export const Divider = React.forwardRef<HTMLElement, DividerProps>(
+  ({ orientation, spacing, color, className, ...props }, ref) => {
+    const classes = cn(dividerVariants({ orientation, spacing, color }), className);
+    if (orientation === 'vertical') {
+      return (
+        <div
+          ref={ref as React.Ref<HTMLDivElement>}
+          role="separator"
+          aria-orientation="vertical"
+          className={classes}
+          {...props}
+        />
+      );
+    }
+    return (
+      <hr
+        ref={ref as React.Ref<HTMLHRElement>}
+        role="separator"
+        className={classes}
+        {...props}
+      />
+    );
+  },
+);
+Divider.displayName = 'Divider';
+
+export { dividerVariants };

--- a/frontend/src/atoms/Divider/index.ts
+++ b/frontend/src/atoms/Divider/index.ts
@@ -1,0 +1,1 @@
+export * from './Divider';


### PR DESCRIPTION
## Summary
- add Divider atom with orientation, spacing, and color variants
- document Divider usage in storybook docs and stories
- add unit tests for Divider component

## Testing
- `npx -y vitest run frontend/src/atoms/Divider/Divider.test.tsx` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6870f9e7a2a8832b9a27f0c117f1b07b