### PR TITLE
Add Breadcrumbs atom

### DIFF
--- a/frontend/src/atoms/Breadcrumbs/Breadcrumbs.docs.mdx
+++ b/frontend/src/atoms/Breadcrumbs/Breadcrumbs.docs.mdx
@@ -1,0 +1,24 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import Breadcrumbs from './Breadcrumbs';
+
+<Meta title="Atoms/Breadcrumbs" of={Breadcrumbs} />
+
+# Breadcrumbs
+
+Breadcrumbs show users where they are in the application hierarchy.
+Provide an array of `{ label, href }` items. The last item represents the current page.
+
+<Canvas>
+  <Story name="Example">
+    <Breadcrumbs
+      items={[
+        { label: 'Inicio', href: '#' },
+        { label: 'Inventario', href: '#' },
+        { label: 'Productos', href: '#' },
+        { label: 'Camisa X' },
+      ]}
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={Breadcrumbs} />

--- a/frontend/src/atoms/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/frontend/src/atoms/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Breadcrumbs, { BreadcrumbsProps } from './Breadcrumbs';
+
+const exampleItems = [
+  { label: 'Inicio', href: '#' },
+  { label: 'Inventario', href: '#' },
+  { label: 'Productos', href: '#' },
+  { label: 'Camisa X' },
+];
+
+const meta: Meta<BreadcrumbsProps> = {
+  title: 'Atoms/Breadcrumbs',
+  component: Breadcrumbs,
+  tags: ['autodocs'],
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    separator: { control: 'text' },
+    className: { table: { disable: true } },
+    items: { table: { disable: true } },
+  },
+  args: {
+    items: exampleItems,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CustomColor: Story = {
+  args: { color: 'primary' },
+};
+
+export const CustomSeparator: Story = {
+  args: { separator: '>' },
+};
+
+export const TwoItems: Story = {
+  args: {
+    items: [
+      { label: 'Inicio', href: '#' },
+      { label: 'Perfil' },
+    ],
+  },
+};

--- a/frontend/src/atoms/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/frontend/src/atoms/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Breadcrumbs from './Breadcrumbs';
+
+const items = [
+  { label: 'Home', href: '/' },
+  { label: 'Catalog', href: '/catalog' },
+  { label: 'Product' },
+];
+
+describe('Breadcrumbs', () => {
+  it('renders all items and separators', () => {
+    render(<Breadcrumbs items={items} />);
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Catalog')).toBeInTheDocument();
+    expect(screen.getByText('Product')).toBeInTheDocument();
+    const separators = screen.getAllByText('/');
+    expect(separators).toHaveLength(items.length - 1);
+  });
+
+  it('renders links for all but the last item', () => {
+    render(<Breadcrumbs items={items} />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(items.length - 1);
+    expect(links[0]).toHaveAttribute('href', '/');
+    expect(links[1]).toHaveAttribute('href', '/catalog');
+    expect(screen.queryByRole('link', { name: 'Product' })).toBeNull();
+  });
+
+  it('marks the last item as current page', () => {
+    render(<Breadcrumbs items={items} />);
+    const current = screen.getByText('Product');
+    expect(current).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/frontend/src/atoms/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/src/atoms/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Link, LinkProps } from '@/atoms/Link/Link';
+import { cn } from '@/lib/utils';
+
+export interface BreadcrumbItem {
+  label: React.ReactNode;
+  href?: string;
+}
+
+export interface BreadcrumbsProps
+  extends React.HTMLAttributes<HTMLElement> {
+  /** Items to render in the breadcrumb trail */
+  items: BreadcrumbItem[];
+  /** Separator symbol between items */
+  separator?: React.ReactNode;
+  /** Color variant for the links */
+  color?: LinkProps['color'];
+}
+
+export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
+  ({ items, separator = '/', className, color = 'secondary', ...props }, ref) => {
+    return (
+      <nav
+        ref={ref}
+        aria-label="Breadcrumb"
+        className={cn('text-sm', className)}
+        {...props}
+      >
+        <ol className="flex flex-wrap items-center">
+          {items.map((item, index) => {
+            const isLast = index === items.length - 1;
+            return (
+              <li key={index} className="flex items-center">
+                {item.href && !isLast ? (
+                  <Link href={item.href} color={color} className="whitespace-nowrap">
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    className="font-medium text-foreground whitespace-nowrap"
+                    aria-current={isLast ? 'page' : undefined}
+                  >
+                    {item.label}
+                  </span>
+                )}
+                {!isLast && (
+                  <span className="mx-2 text-muted-foreground">{separator}</span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    );
+  },
+);
+Breadcrumbs.displayName = 'Breadcrumbs';
+
+export default Breadcrumbs;

--- a/frontend/src/atoms/Breadcrumbs/index.ts
+++ b/frontend/src/atoms/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumbs';


### PR DESCRIPTION
## Summary
- add Breadcrumbs atom with customizable color and separator
- document Breadcrumbs usage in Storybook
- provide Storybook stories and tests

## Testing
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6870fa01d2bc832bb8b1194662cfd500