### PR TITLE
Improve Avatar styles

### DIFF
--- a/frontend/src/atoms/Avatar/Avatar.docs.mdx
+++ b/frontend/src/atoms/Avatar/Avatar.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Avatar } from './Avatar';
+
+<Meta title="Atoms/Avatar" of={Avatar} />
+
+# Avatar
+
+The `Avatar` component displays a user or entity image. If no image is provided or it fails to load, it falls back to initials or a generic user icon. It also includes a subtle shadow and a small hover animation for a polished feel.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="flex items-center gap-4">
+      <Avatar src="https://placehold.co/60" alt="User" />
+      <Avatar name="Jane Doe" color="primary" />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Avatar} />

--- a/frontend/src/atoms/Avatar/Avatar.stories.tsx
+++ b/frontend/src/atoms/Avatar/Avatar.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Avatar, AvatarProps } from './Avatar';
+
+const meta: Meta<AvatarProps> = {
+  title: 'Atoms/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    color: {
+      control: 'select',
+      options: ['muted', 'primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    src: { control: 'text' },
+    name: { control: 'text' },
+    alt: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Image: Story = {
+  args: {
+    src: 'https://placehold.co/100x100',
+    alt: 'Avatar',
+  },
+};
+
+export const Initials: Story = {
+  args: {
+    name: 'John Doe',
+    color: 'primary',
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      <Avatar {...args} size="sm" src="https://placehold.co/40" />
+      <Avatar {...args} size="md" src="https://placehold.co/60" />
+      <Avatar {...args} size="lg" src="https://placehold.co/100" />
+    </div>
+  ),
+  args: {},
+};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      <Avatar {...args} name="AA" color="primary" />
+      <Avatar {...args} name="BB" color="secondary" />
+      <Avatar {...args} name="CC" color="tertiary" />
+      <Avatar {...args} name="DD" color="quaternary" />
+      <Avatar {...args} name="EE" color="success" />
+    </div>
+  ),
+  args: {},
+};
+
+export const HoverEffect: Story = {
+  args: {
+    src: 'https://placehold.co/100x100',
+    alt: 'Hover avatar',
+  },
+};

--- a/frontend/src/atoms/Avatar/Avatar.test.tsx
+++ b/frontend/src/atoms/Avatar/Avatar.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Avatar } from './Avatar';
+
+describe('Avatar', () => {
+  it('renders an image when src is provided', () => {
+    render(<Avatar src="avatar.png" alt="Profile" data-testid="avatar" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'avatar.png');
+    expect(img).toHaveAttribute('alt', 'Profile');
+  });
+
+  it('uses name as alt text by default', () => {
+    render(<Avatar src="avatar.png" name="Jane Doe" data-testid="avatar" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Jane Doe');
+  });
+
+  it('falls back to initials when no src', () => {
+    render(<Avatar name="John Doe" data-testid="avatar" />);
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('applies size variants', () => {
+    const { rerender } = render(<Avatar size="sm" data-testid="avatar" />);
+    const container = screen.getByTestId('avatar');
+    expect(container.className).toContain('h-6');
+
+    // default classes include shadow and hover animation
+    expect(container.className).toContain('shadow-sm');
+
+    rerender(<Avatar size="lg" data-testid="avatar" />);
+    expect(container.className).toContain('h-16');
+  });
+
+  it('shows initials when image fails to load', () => {
+    render(<Avatar src="bad.png" name="Alice" data-testid="avatar" />);
+    const img = screen.getByRole('img');
+    fireEvent.error(img);
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/atoms/Avatar/Avatar.tsx
+++ b/frontend/src/atoms/Avatar/Avatar.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { User } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const avatarVariants = cva(
+  'relative inline-flex items-center justify-center overflow-hidden rounded-full bg-muted select-none text-muted-foreground shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5',
+  {
+    variants: {
+      size: {
+        sm: 'h-6 w-6 text-xs',
+        md: 'h-10 w-10 text-sm',
+        lg: 'h-16 w-16 text-lg',
+      },
+      color: {
+        primary: 'bg-primary text-primary-foreground',
+        secondary: 'bg-secondary text-secondary-foreground',
+        tertiary: 'bg-tertiary text-tertiary-foreground',
+        quaternary: 'bg-quaternary text-quaternary-foreground',
+        success: 'bg-success text-success-foreground',
+        muted: 'bg-muted text-muted-foreground',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+      color: 'muted',
+    },
+  },
+);
+
+export interface AvatarProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof avatarVariants> {
+  src?: string;
+  alt?: string;
+  name?: string;
+}
+
+const getInitials = (name: string) => {
+  return name
+    .split(/\s+/)
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+};
+
+export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
+  ({ className, size, color, src, alt, name, ...props }, ref) => {
+    const [error, setError] = React.useState(false);
+    const showImage = src && !error;
+    const initials = name ? getInitials(name) : undefined;
+
+    return (
+      <div ref={ref} className={cn(avatarVariants({ size, color }), className)} {...props}>
+        {showImage ? (
+          <img
+            src={src}
+            alt={alt ?? name ?? 'Avatar'}
+            className="h-full w-full object-cover"
+            onError={() => setError(true)}
+          />
+        ) : initials ? (
+          <span aria-hidden="true" className="font-medium">
+            {initials}
+          </span>
+        ) : (
+          <User className="h-2/3 w-2/3" aria-hidden="true" />
+        )}
+      </div>
+    );
+  },
+);
+Avatar.displayName = 'Avatar';
+
+export { avatarVariants };

--- a/frontend/src/atoms/Avatar/index.ts
+++ b/frontend/src/atoms/Avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './Avatar';


### PR DESCRIPTION
## Summary
- refine Avatar style with a subtle shadow and hover animation
- document the new look and add a story example
- update unit tests for the additional classes

## Testing
- `pnpm --dir frontend test --run`


------
https://chatgpt.com/codex/tasks/task_e_6870fa182cbc832b83602731b25ebb0e