### PR TITLE
Add Badge atom

### DIFF
--- a/frontend/src/atoms/Badge/Badge.docs.mdx
+++ b/frontend/src/atoms/Badge/Badge.docs.mdx
@@ -1,0 +1,21 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Badge } from './Badge';
+
+<Meta title="Atoms/Badge" of={Badge} />
+
+# Badge
+
+The `Badge` component displays a small label for counts or status information. Use the `variant` prop to adjust its color.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <Badge variant="success">Activo</Badge>
+      <Badge variant="warning" className="ml-2">En curso</Badge>
+      <Badge variant="destructive" className="ml-2">Error</Badge>
+      <Badge variant="info" className="ml-2">99+</Badge>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Badge} />

--- a/frontend/src/atoms/Badge/Badge.stories.tsx
+++ b/frontend/src/atoms/Badge/Badge.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Badge, BadgeProps } from './Badge';
+
+const meta: Meta<BadgeProps> = {
+  title: 'Atoms/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['neutral', 'success', 'warning', 'destructive', 'info'],
+    },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: 'Badge' },
+};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="space-x-2">
+      <Badge {...args} variant="success">Success</Badge>
+      <Badge {...args} variant="warning">Warning</Badge>
+      <Badge {...args} variant="destructive">Error</Badge>
+      <Badge {...args} variant="info">Info</Badge>
+      <Badge {...args} variant="neutral">Neutral</Badge>
+    </div>
+  ),
+  args: {},
+};

--- a/frontend/src/atoms/Badge/Badge.test.tsx
+++ b/frontend/src/atoms/Badge/Badge.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Badge } from './Badge';
+
+describe('Badge', () => {
+  it('renders its children', () => {
+    render(<Badge>New</Badge>);
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('applies default variant classes', () => {
+    render(<Badge>Default</Badge>);
+    const badge = screen.getByText('Default');
+    expect(badge.className).toContain('bg-muted');
+    expect(badge).toHaveClass('inline-flex');
+  });
+
+  it('applies variant class', () => {
+    render(<Badge variant="success">Ok</Badge>);
+    expect(screen.getByText('Ok').className).toContain('bg-success');
+  });
+
+  it('merges custom class names', () => {
+    render(<Badge className="custom">A</Badge>);
+    const badge = screen.getByText('A');
+    expect(badge).toHaveClass('custom');
+    expect(badge).toHaveClass('rounded-full');
+  });
+});

--- a/frontend/src/atoms/Badge/Badge.tsx
+++ b/frontend/src/atoms/Badge/Badge.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold',
+  {
+    variants: {
+      variant: {
+        neutral: 'bg-muted text-foreground',
+        success: 'bg-success text-white',
+        warning: 'bg-quaternary text-foreground',
+        destructive: 'bg-tertiary text-white',
+        info: 'bg-secondary text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'neutral',
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <span ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />
+    );
+  },
+);
+
+Badge.displayName = 'Badge';
+
+export { Badge, badgeVariants };

--- a/frontend/src/atoms/Badge/index.ts
+++ b/frontend/src/atoms/Badge/index.ts
@@ -1,0 +1,1 @@
+export * from './Badge';


### PR DESCRIPTION
## Summary
- add Badge atom component with variant styling
- document Badge stories and docs in Storybook
- add tests for Badge variant and class merging

## Testing
- `pnpm exec vitest run --reporter=dot`

------
https://chatgpt.com/codex/tasks/task_e_6870fa2eb9b4832bb77f587713157f6e