### PR TITLE
Add Tag component

### DIFF
--- a/frontend/src/atoms/Tag/Tag.docs.mdx
+++ b/frontend/src/atoms/Tag/Tag.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Tag } from './Tag';
+
+<Meta title="Atoms/Tag" of={Tag} />
+
+# Tag
+
+The `Tag` component displays small labels used for categorization or selected filters. Use the `variant` and `color` props to match your theme. Enable `closable` to show a remove button.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <Tag>Etiqueta</Tag>
+      <Tag variant="solid" color="secondary" className="ml-2">VIP</Tag>
+      <Tag closable className="ml-2">Filtro: Azul</Tag>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Tag} />

--- a/frontend/src/atoms/Tag/Tag.stories.tsx
+++ b/frontend/src/atoms/Tag/Tag.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tag, TagProps } from './Tag';
+
+const meta: Meta<TagProps> = {
+  title: 'Atoms/Tag',
+  component: Tag,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['outline', 'solid'] },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+    },
+    closable: { control: 'boolean' },
+    removeLabel: { control: 'text' },
+    children: { control: 'text' },
+    onRemove: { action: 'removed', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: 'Etiqueta' },
+};
+
+export const Solid: Story = {
+  args: { variant: 'solid', color: 'secondary', children: 'VIP' },
+};
+
+export const Closable: Story = {
+  args: { closable: true, children: 'Filtro: Azul' },
+};

--- a/frontend/src/atoms/Tag/Tag.test.tsx
+++ b/frontend/src/atoms/Tag/Tag.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Tag } from './Tag';
+
+describe('Tag', () => {
+  it('renders its children', () => {
+    render(<Tag>Test</Tag>);
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+
+  it('applies default outline styles', () => {
+    render(<Tag>Default</Tag>);
+    const tag = screen.getByText('Default');
+    expect(tag.className).toContain('border-primary');
+    expect(tag.className).toContain('text-primary');
+  });
+
+  it('applies solid variant classes', () => {
+    render(
+      <Tag variant="solid" color="secondary">
+        Solid
+      </Tag>
+    );
+    const tag = screen.getByText('Solid');
+    expect(tag.className).toContain('bg-secondary');
+    expect(tag.className).toContain('text-secondary-foreground');
+  });
+
+  it('renders close button and handles click', () => {
+    const onRemove = vi.fn();
+    render(<Tag closable onRemove={onRemove}>Filter</Tag>);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(onRemove).toHaveBeenCalled();
+    expect(button).toHaveAttribute('aria-label', 'Quitar etiqueta');
+  });
+});

--- a/frontend/src/atoms/Tag/Tag.tsx
+++ b/frontend/src/atoms/Tag/Tag.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const tagVariants = cva(
+  'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+  {
+    variants: {
+      variant: {
+        outline: 'bg-transparent',
+        solid: '',
+      },
+      color: {
+        primary: '',
+        secondary: '',
+        tertiary: '',
+        quaternary: '',
+        success: '',
+        destructive: '',
+      },
+    },
+    compoundVariants: [
+      {
+        variant: 'solid',
+        color: 'primary',
+        className: 'bg-primary text-primary-foreground border-transparent',
+      },
+      {
+        variant: 'solid',
+        color: 'secondary',
+        className: 'bg-secondary text-secondary-foreground border-transparent',
+      },
+      {
+        variant: 'solid',
+        color: 'tertiary',
+        className: 'bg-tertiary text-tertiary-foreground border-transparent',
+      },
+      {
+        variant: 'solid',
+        color: 'quaternary',
+        className: 'bg-quaternary text-quaternary-foreground border-transparent',
+      },
+      {
+        variant: 'solid',
+        color: 'success',
+        className: 'bg-success text-success-foreground border-transparent',
+      },
+      {
+        variant: 'solid',
+        color: 'destructive',
+        className: 'bg-destructive text-destructive-foreground border-transparent',
+      },
+      { variant: 'outline', color: 'primary', className: 'text-primary border-primary' },
+      {
+        variant: 'outline',
+        color: 'secondary',
+        className: 'text-secondary border-secondary',
+      },
+      { variant: 'outline', color: 'tertiary', className: 'text-tertiary border-tertiary' },
+      {
+        variant: 'outline',
+        color: 'quaternary',
+        className: 'text-quaternary border-quaternary',
+      },
+      { variant: 'outline', color: 'success', className: 'text-success border-success' },
+      {
+        variant: 'outline',
+        color: 'destructive',
+        className: 'text-destructive border-destructive',
+      },
+    ],
+    defaultVariants: {
+      variant: 'outline',
+      color: 'primary',
+    },
+  }
+);
+
+export interface TagProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof tagVariants> {
+  /** Show a close button to remove the tag */
+  closable?: boolean;
+  /** Callback when the close button is clicked */
+  onRemove?: () => void;
+  /** Accessible label for the close button */
+  removeLabel?: string;
+}
+
+export const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
+  (
+    { className, variant, color, closable = false, onRemove, removeLabel, children, ...props },
+    ref
+  ) => {
+    return (
+      <span ref={ref} className={cn(tagVariants({ variant, color }), className)} {...props}>
+        {children}
+        {closable && (
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label={removeLabel ?? 'Quitar etiqueta'}
+            className="ml-1 flex h-4 w-4 items-center justify-center rounded-full hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </span>
+    );
+  }
+);
+Tag.displayName = 'Tag';
+
+export { tagVariants };

--- a/frontend/src/atoms/Tag/index.ts
+++ b/frontend/src/atoms/Tag/index.ts
@@ -1,0 +1,1 @@
+export * from './Tag';


### PR DESCRIPTION
## Summary
- create Tag atom with outline and solid variants
- add unit tests for Tag behavior
- document Tag usage in Storybook
- provide stories for default, solid, and closable tags

## Testing
- `npm install` within `frontend`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870fa4fc94c832b835f47c01a4a51bf