### PR TITLE
Add Tooltip atom

### DIFF
--- a/frontend/src/atoms/Tooltip/Tooltip.docs.mdx
+++ b/frontend/src/atoms/Tooltip/Tooltip.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Tooltip } from './Tooltip';
+import { Button } from '@/atoms/Button/Button';
+
+<Meta title="Atoms/Tooltip" of={Tooltip} />
+
+# Tooltip
+
+The `Tooltip` component displays brief helper text when users hover or focus the wrapped element.
+
+<Canvas>
+  <Story name="Example">
+    <Tooltip content="Saves your changes">
+      <Button intent="primary">Save</Button>
+    </Tooltip>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Tooltip} />

--- a/frontend/src/atoms/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tooltip, TooltipProps } from './Tooltip';
+import { Button } from '@/atoms/Button/Button';
+
+interface TooltipStoryProps extends TooltipProps {
+  label?: string;
+}
+
+const meta: Meta<TooltipStoryProps> = {
+  title: 'Atoms/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  argTypes: {
+    intent: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    placement: {
+      control: 'select',
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+    content: { control: 'text' },
+    label: { control: 'text' },
+    children: { table: { disable: true } },
+    className: { table: { disable: true } },
+  },
+  args: {
+    content: 'Tooltip content',
+    label: 'Hover me',
+  },
+  render: ({ label, ...args }) => (
+    <Tooltip {...args}>
+      <Button intent="secondary">{label}</Button>
+    </Tooltip>
+  ),
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Placements: Story = {
+  render: (args) => (
+    <div className="flex gap-8 items-center justify-center flex-wrap">
+      <Tooltip {...args} placement="top">
+        <Button intent="secondary">Top</Button>
+      </Tooltip>
+      <Tooltip {...args} placement="bottom">
+        <Button intent="secondary">Bottom</Button>
+      </Tooltip>
+      <Tooltip {...args} placement="left">
+        <Button intent="secondary">Left</Button>
+      </Tooltip>
+      <Tooltip {...args} placement="right">
+        <Button intent="secondary">Right</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Intents: Story = {
+  render: (args) => (
+    <div className="flex gap-4 flex-wrap">
+      <Tooltip {...args} intent="primary">
+        <Button intent="primary">Primary</Button>
+      </Tooltip>
+      <Tooltip {...args} intent="secondary">
+        <Button intent="secondary">Secondary</Button>
+      </Tooltip>
+      <Tooltip {...args} intent="tertiary">
+        <Button intent="tertiary">Tertiary</Button>
+      </Tooltip>
+      <Tooltip {...args} intent="quaternary">
+        <Button intent="quaternary">Quaternary</Button>
+      </Tooltip>
+      <Tooltip {...args} intent="success">
+        <Button intent="success">Success</Button>
+      </Tooltip>
+    </div>
+  ),
+};

--- a/frontend/src/atoms/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Tooltip } from './Tooltip';
+
+function Trigger() {
+  return <button>Trigger</button>;
+}
+
+describe('Tooltip', () => {
+  it('shows tooltip on hover and hides on mouse leave', () => {
+    render(
+      <Tooltip content="Info">
+        <Trigger />
+      </Tooltip>,
+    );
+    const trigger = screen.getByRole('button', { name: /trigger/i });
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.mouseLeave(trigger);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('shows tooltip on focus and hides on blur', () => {
+    render(
+      <Tooltip content="Help">
+        <Trigger />
+      </Tooltip>,
+    );
+    const trigger = screen.getByRole('button', { name: /trigger/i });
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.blur(trigger);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('applies placement classes', () => {
+    render(
+      <Tooltip content="Text" placement="bottom">
+        <Trigger />
+      </Tooltip>,
+    );
+    const trigger = screen.getByRole('button');
+    fireEvent.mouseEnter(trigger);
+    const tip = screen.getByRole('tooltip');
+    expect(tip.className).toContain('top-full');
+  });
+});

--- a/frontend/src/atoms/Tooltip/Tooltip.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const tooltipVariants = cva(
+  'absolute z-50 rounded px-2 py-1 text-xs shadow-md whitespace-nowrap',
+  {
+    variants: {
+      intent: {
+        primary: 'bg-primary text-primary-foreground',
+        secondary: 'bg-secondary text-secondary-foreground',
+        tertiary: 'bg-tertiary text-tertiary-foreground',
+        quaternary: 'bg-quaternary text-quaternary-foreground',
+        success: 'bg-success text-success-foreground',
+      },
+      placement: {
+        top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+        bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+        left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+        right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+      },
+    },
+    defaultVariants: {
+      intent: 'secondary',
+      placement: 'top',
+    },
+  },
+);
+
+const arrowVariants = cva('absolute w-2 h-2 rotate-45', {
+  variants: {
+    intent: {
+      primary: 'bg-primary',
+      secondary: 'bg-secondary',
+      tertiary: 'bg-tertiary',
+      quaternary: 'bg-quaternary',
+      success: 'bg-success',
+    },
+    placement: {
+      top: '-bottom-1 left-1/2 -translate-x-1/2',
+      bottom: '-top-1 left-1/2 -translate-x-1/2',
+      left: '-right-1 top-1/2 -translate-y-1/2',
+      right: '-left-1 top-1/2 -translate-y-1/2',
+    },
+  },
+  defaultVariants: {
+    intent: 'secondary',
+    placement: 'top',
+  },
+});
+
+export interface TooltipProps extends VariantProps<typeof tooltipVariants> {
+  /** Tooltip text or element */
+  content: React.ReactNode;
+  /** Additional classes for the wrapper */
+  className?: string;
+  /** Element that triggers the tooltip */
+  children: React.ReactElement;
+}
+
+const Tooltip = React.forwardRef<HTMLSpanElement, TooltipProps>(
+  ({ content, children, intent, placement, className }, ref) => {
+    const [open, setOpen] = React.useState(false);
+    const id = React.useId();
+
+    const show = () => setOpen(true);
+    const hide = () => setOpen(false);
+
+    const child = React.cloneElement(children, {
+      onMouseEnter: (e: React.MouseEvent) => {
+        children.props.onMouseEnter?.(e);
+        show();
+      },
+      onMouseLeave: (e: React.MouseEvent) => {
+        children.props.onMouseLeave?.(e);
+        hide();
+      },
+      onFocus: (e: React.FocusEvent) => {
+        children.props.onFocus?.(e);
+        show();
+      },
+      onBlur: (e: React.FocusEvent) => {
+        children.props.onBlur?.(e);
+        hide();
+      },
+      'aria-describedby': id,
+    });
+
+    return (
+      <span className={cn('relative inline-block', className)} ref={ref}>
+        {child}
+        {open && (
+          <span
+            role="tooltip"
+            id={id}
+            className={cn(tooltipVariants({ intent, placement }))}
+          >
+            {content}
+            <span className={cn(arrowVariants({ intent, placement }))} />
+          </span>
+        )}
+      </span>
+    );
+  },
+);
+Tooltip.displayName = 'Tooltip';
+
+export { Tooltip, tooltipVariants };

--- a/frontend/src/atoms/Tooltip/index.ts
+++ b/frontend/src/atoms/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './Tooltip';


### PR DESCRIPTION
## Summary
- implement Tooltip atom with placement and intent variants
- document Tooltip via Storybook docs & stories
- add Tooltip unit tests

## Testing
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fa7412cc832b94afaf8ebdc740f0