### PR TITLE
Add Tooltip atom

### DIFF
--- a/frontend/src/atoms/Tooltip/Tooltip.docs.mdx
+++ b/frontend/src/atoms/Tooltip/Tooltip.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Tooltip } from './Tooltip';
+import { Button } from '../Button/Button';
+
+<Meta title="Atoms/Tooltip" of={Tooltip} />
+
+# Tooltip
+
+The `Tooltip` component displays supplemental information when users hover or focus on an element.
+
+<Canvas>
+  <Story name="Example">
+    <Tooltip content="Save changes">
+      <Button variant="outline">Hover me</Button>
+    </Tooltip>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Tooltip} />

--- a/frontend/src/atoms/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../Button/Button';
+import { Tooltip, TooltipProps } from './Tooltip';
+
+const meta: Meta<TooltipProps> = {
+  title: 'Atoms/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  argTypes: {
+    placement: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
+    intent: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    content: { control: 'text' },
+    children: { table: { disable: true } },
+  },
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button variant="outline">Hover me</Button>
+    </Tooltip>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { content: 'Helpful info', placement: 'top', intent: 'primary' },
+};
+
+export const Placements: Story = {
+  render: (args) => (
+    <div className="flex gap-8">
+      <Tooltip {...args} placement="top" content="Top">
+        <Button variant="outline">Top</Button>
+      </Tooltip>
+      <Tooltip {...args} placement="right" content="Right">
+        <Button variant="outline">Right</Button>
+      </Tooltip>
+      <Tooltip {...args} placement="bottom" content="Bottom">
+        <Button variant="outline">Bottom</Button>
+      </Tooltip>
+      <Tooltip {...args} placement="left" content="Left">
+        <Button variant="outline">Left</Button>
+      </Tooltip>
+    </div>
+  ),
+  args: { intent: 'primary' },
+};

--- a/frontend/src/atoms/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Tooltip } from './Tooltip';
+
+describe('Tooltip', () => {
+  it('shows and hides on hover', () => {
+    render(
+      <Tooltip content="Info">
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    const trigger = screen.getByRole('button');
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByText('Info')).toBeInTheDocument();
+    fireEvent.mouseLeave(trigger);
+    expect(screen.queryByText('Info')).not.toBeInTheDocument();
+  });
+
+  it('shows on focus', () => {
+    render(
+      <Tooltip content="More">
+        <button>Focus me</button>
+      </Tooltip>
+    );
+    const trigger = screen.getByRole('button');
+    fireEvent.focus(trigger);
+    expect(screen.getByText('More')).toBeInTheDocument();
+  });
+
+  it('applies placement classes', () => {
+    render(
+      <Tooltip content="Hi" placement="bottom">
+        <button>Hi</button>
+      </Tooltip>
+    );
+    const trigger = screen.getByRole('button');
+    fireEvent.mouseEnter(trigger);
+    const tip = screen.getByRole('tooltip');
+    expect(tip.className).toContain('top-full');
+  });
+});

--- a/frontend/src/atoms/Tooltip/Tooltip.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const tooltipVariants = cva(
+  'absolute z-50 inline-block rounded-md px-2 py-1 text-xs shadow-md',
+  {
+    variants: {
+      placement: {
+        top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+        bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+        left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+        right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+      },
+      intent: {
+        primary: 'bg-neutral-800 text-white',
+        secondary: 'bg-secondary text-secondary-foreground',
+        tertiary: 'bg-tertiary text-tertiary-foreground',
+        quaternary: 'bg-quaternary text-quaternary-foreground',
+        success: 'bg-success text-success-foreground',
+      },
+    },
+    defaultVariants: {
+      placement: 'top',
+      intent: 'primary',
+    },
+  },
+);
+
+const arrowVariants = cva('absolute w-2 h-2 rotate-45', {
+  variants: {
+    placement: {
+      top: 'left-1/2 -translate-x-1/2 -bottom-1',
+      bottom: 'left-1/2 -translate-x-1/2 -top-1',
+      left: 'top-1/2 -translate-y-1/2 -right-1',
+      right: 'top-1/2 -translate-y-1/2 -left-1',
+    },
+    intent: {
+      primary: 'bg-neutral-800',
+      secondary: 'bg-secondary',
+      tertiary: 'bg-tertiary',
+      quaternary: 'bg-quaternary',
+      success: 'bg-success',
+    },
+  },
+  defaultVariants: {
+    placement: 'top',
+    intent: 'primary',
+  },
+});
+
+export interface TooltipProps extends VariantProps<typeof tooltipVariants> {
+  /** Tooltip text or content */
+  content: React.ReactNode;
+  /** Element that triggers the tooltip */
+  children: React.ReactElement;
+}
+
+export const Tooltip = ({
+  children,
+  content,
+  placement,
+  intent,
+}: TooltipProps) => {
+  const [open, setOpen] = React.useState(false);
+  const id = React.useId();
+
+  const show = () => setOpen(true);
+  const hide = () => setOpen(false);
+
+  const child = React.cloneElement(children, {
+    onMouseEnter: (e: React.MouseEvent) => {
+      children.props.onMouseEnter?.(e);
+      show();
+    },
+    onMouseLeave: (e: React.MouseEvent) => {
+      children.props.onMouseLeave?.(e);
+      hide();
+    },
+    onFocus: (e: React.FocusEvent) => {
+      children.props.onFocus?.(e);
+      show();
+    },
+    onBlur: (e: React.FocusEvent) => {
+      children.props.onBlur?.(e);
+      hide();
+    },
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') hide();
+      children.props.onKeyDown?.(e);
+    },
+    'aria-describedby': id,
+  });
+
+  return (
+    <span className="relative inline-block">
+      {child}
+      {open && (
+        <span
+          role="tooltip"
+          id={id}
+          className={cn(tooltipVariants({ placement, intent }))}
+        >
+          {content}
+          <span className={cn(arrowVariants({ placement, intent }))} />
+        </span>
+      )}
+    </span>
+  );
+};
+
+Tooltip.displayName = 'Tooltip';
+
+export { tooltipVariants };

--- a/frontend/src/atoms/Tooltip/index.ts
+++ b/frontend/src/atoms/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './Tooltip';


### PR DESCRIPTION
## Summary
- add Tooltip atom component with placement and color variants
- create Tooltip docs, stories, and unit tests

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fa7412cc832b94afaf8ebdc740f0