### PR TITLE
Add Alert atom

### DIFF
--- a/frontend/src/atoms/Alert/Alert.docs.mdx
+++ b/frontend/src/atoms/Alert/Alert.docs.mdx
@@ -1,0 +1,22 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Alert } from './Alert';
+
+<Meta title="Atoms/Alert" of={Alert} />
+
+# Alert
+
+The `Alert` component displays feedback messages for various states such as success, error, warning and information. Use the `variant` prop to change the color scheme. If `dismissable` is enabled, users can close the alert.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <Alert variant="success" title="Éxito">Cliente guardado con éxito.</Alert>
+      <Alert variant="error" title="Error" className="mt-4">Error al cargar datos.</Alert>
+      <Alert variant="warning" title="Advertencia" className="mt-4">Falta completar un campo.</Alert>
+      <Alert variant="info" title="Info" className="mt-4" dismissable>Puede cerrar este mensaje.</Alert>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Alert} />
+

--- a/frontend/src/atoms/Alert/Alert.stories.tsx
+++ b/frontend/src/atoms/Alert/Alert.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Alert, AlertProps } from './Alert';
+
+const meta: Meta<AlertProps> = {
+  title: 'Atoms/Alert',
+  component: Alert,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['info', 'success', 'warning', 'error'] },
+    title: { control: 'text' },
+    dismissable: { control: 'boolean' },
+    children: { control: 'text' },
+    onClose: { action: 'closed', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {
+  args: {
+    variant: 'info',
+    title: 'Información',
+    children: 'Su sesión expirará pronto.',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    variant: 'success',
+    title: 'Éxito',
+    children: 'Cliente guardado con éxito.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: 'warning',
+    title: 'Advertencia',
+    children: 'Falta completar un campo.',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    title: 'Error',
+    children: 'Error al cargar datos.',
+  },
+};
+
+export const Dismissable: Story = {
+  args: {
+    variant: 'info',
+    title: 'Notificación',
+    children: 'Puede cerrar este mensaje.',
+    dismissable: true,
+  },
+};
+

--- a/frontend/src/atoms/Alert/Alert.test.tsx
+++ b/frontend/src/atoms/Alert/Alert.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Alert } from './Alert';
+
+describe('Alert', () => {
+  it('renders message text', () => {
+    render(<Alert>Mensaje</Alert>);
+    expect(screen.getByText('Mensaje')).toBeInTheDocument();
+  });
+
+  it('applies variant classes', () => {
+    render(<Alert variant="success">ok</Alert>);
+    const alert = screen.getByRole('alert');
+    expect(alert.className).toContain('border-success');
+  });
+
+  it('shows corresponding icon', () => {
+    render(<Alert variant="error">fail</Alert>);
+    const svg = screen.getByRole('alert').querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('calls onClose when dismissed', () => {
+    const handleClose = vi.fn();
+    render(
+      <Alert dismissable onClose={handleClose} title="test">
+        text
+      </Alert>
+    );
+    const button = screen.getByRole('button', { name: /cerrar alerta/i });
+    fireEvent.click(button);
+    expect(handleClose).toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/atoms/Alert/Alert.tsx
+++ b/frontend/src/atoms/Alert/Alert.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Info, CheckCircle2, AlertTriangle, AlertCircle, X } from 'lucide-react';
+
+const alertVariants = cva(
+  'relative w-full flex items-start gap-2 rounded-md border-l-4 p-4 text-sm',
+  {
+    variants: {
+      variant: {
+        info: 'bg-secondary/20 text-secondary border-secondary',
+        success: 'bg-success/20 text-success border-success',
+        warning: 'bg-quaternary/20 text-quaternary border-quaternary',
+        error: 'bg-destructive/20 text-destructive border-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'info',
+    },
+  },
+);
+
+type AlertVariant = VariantProps<typeof alertVariants>['variant'];
+
+const iconMap: Record<AlertVariant, React.ElementType> = {
+  info: Info,
+  success: CheckCircle2,
+  warning: AlertTriangle,
+  error: AlertCircle,
+};
+
+export interface AlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {
+  title?: string;
+  dismissable?: boolean;
+  onClose?: () => void;
+}
+
+export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  (
+    { className, variant, title, children, dismissable = false, onClose, ...props },
+    ref,
+  ) => {
+    const [visible, setVisible] = React.useState(true);
+    const Icon = iconMap[variant ?? 'info'];
+
+    const handleClose = () => {
+      onClose?.();
+      setVisible(false);
+    };
+
+    if (!visible) return null;
+
+    return (
+      <div
+        role="alert"
+        ref={ref}
+        className={cn(alertVariants({ variant, className }))}
+        {...props}
+      >
+        <Icon className="mt-0.5 flex-shrink-0" size={20} aria-hidden="true" />
+        <div className="flex-1">
+          {title && <h5 className="font-semibold mb-1">{title}</h5>}
+          {children}
+        </div>
+        {dismissable && (
+          <button
+            type="button"
+            onClick={handleClose}
+            aria-label="Cerrar alerta"
+            className="absolute top-2 right-2 rounded p-1 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+          >
+            <X size={14} />
+          </button>
+        )}
+      </div>
+    );
+  },
+);
+Alert.displayName = 'Alert';
+

--- a/frontend/src/atoms/Alert/index.ts
+++ b/frontend/src/atoms/Alert/index.ts
@@ -1,0 +1,1 @@
+export * from './Alert';


### PR DESCRIPTION
## Summary
- implement new `Alert` atom component
- include unit tests for the alert
- add Storybook stories and docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870fa884594832bb1622a2220446fc8