### PR TITLE
Add Modal atom

### DIFF
--- a/frontend/src/atoms/Modal/Modal.docs.mdx
+++ b/frontend/src/atoms/Modal/Modal.docs.mdx
@@ -1,0 +1,31 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Modal } from './Modal';
+import { Button } from '../Button/Button';
+
+<Meta title="Atoms/Modal" of={Modal} />
+
+# Modal
+
+The `Modal` component displays content in a layer above the application and blocks interaction until dismissed. Use it for quick forms or confirmations.
+
+<Canvas>
+  <Story name="Example">
+    {() => {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <Button onClick={() => setOpen(true)}>Open</Button>
+          <Modal isOpen={open} onClose={() => setOpen(false)} title="Example">
+            <p className="mb-4">This is a modal.</p>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+              <Button onClick={() => setOpen(false)}>Accept</Button>
+            </div>
+          </Modal>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Modal} />

--- a/frontend/src/atoms/Modal/Modal.stories.tsx
+++ b/frontend/src/atoms/Modal/Modal.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Modal, ModalProps } from './Modal';
+import { Button } from '../Button/Button';
+
+const meta: Meta<ModalProps> = {
+  title: 'Atoms/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'glass'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    isOpen: { control: 'boolean' },
+    onClose: { action: 'close', table: { category: 'Events' } },
+    title: { control: 'text' },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    title: 'Simple Modal',
+    children: 'Lorem ipsum dolor sit amet.',
+  },
+};
+
+export const WithActions: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <Modal {...args} isOpen={open} onClose={() => setOpen(false)}>
+          <p className="mb-4">Are you sure?</p>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => setOpen(false)}>Confirm</Button>
+          </div>
+        </Modal>
+      </>
+    );
+  },
+  args: {
+    variant: 'glass',
+    size: 'md',
+    title: 'Confirm',
+  },
+};

--- a/frontend/src/atoms/Modal/Modal.test.tsx
+++ b/frontend/src/atoms/Modal/Modal.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Modal } from './Modal';
+
+const renderModal = (isOpen: boolean, onClose = vi.fn()) =>
+  render(
+    <Modal isOpen={isOpen} onClose={onClose} title="Test Modal">
+      <p>content</p>
+      <button>ok</button>
+    </Modal>,
+  );
+
+describe('Modal', () => {
+  it('renders when open', () => {
+    renderModal(true);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    renderModal(false);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when overlay clicked', () => {
+    const onClose = vi.fn();
+    renderModal(true, onClose);
+    fireEvent.click(screen.getByRole('dialog').previousSibling as Element);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when Escape key pressed', () => {
+    const onClose = vi.fn();
+    renderModal(true, onClose);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('focuses the modal when opened', () => {
+    renderModal(true);
+    expect(screen.getByRole('dialog')).toHaveFocus();
+  });
+});

--- a/frontend/src/atoms/Modal/Modal.tsx
+++ b/frontend/src/atoms/Modal/Modal.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const modalVariants = cva(
+  'relative w-full rounded-md p-6 shadow-lg focus:outline-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-white',
+        glass: 'bg-surfaceGlass backdrop-blur-lg shadow-glass',
+      },
+      size: {
+        sm: 'max-w-sm',
+        md: 'max-w-md',
+        lg: 'max-w-lg',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+    },
+  },
+);
+
+export interface ModalProps extends VariantProps<typeof modalVariants> {
+  /** Controls visibility */
+  isOpen: boolean;
+  /** Callback when user requests to close */
+  onClose: () => void;
+  /** Optional title for aria-labelledby */
+  title?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  className,
+  children,
+  variant,
+  size,
+}) => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const lastFocused = React.useRef<Element | null>(null);
+
+  React.useEffect(() => {
+    if (isOpen) {
+      lastFocused.current = document.activeElement;
+      const container = containerRef.current;
+      if (container) {
+        // delay focus to allow portal mount
+        setTimeout(() => container.focus(), 0);
+      }
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          onClose();
+        } else if (e.key === 'Tab') {
+          const focusable = container?.querySelectorAll<HTMLElement>(
+            'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])',
+          );
+          if (!focusable || focusable.length === 0) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (e.shiftKey) {
+            if (document.activeElement === first) {
+              e.preventDefault();
+              last.focus();
+            }
+          } else if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      };
+      document.addEventListener('keydown', handleKeyDown);
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+        (lastFocused.current as HTMLElement | null)?.focus?.();
+      };
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? 'modal-title' : undefined}
+        className={cn(modalVariants({ variant, size, className }))}
+        ref={containerRef}
+        tabIndex={-1}
+      >
+        {title && (
+          <h2 id="modal-title" className="text-lg font-semibold mb-4">
+            {title}
+          </h2>
+        )}
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute top-2 right-2 rounded-md p-1 text-muted hover:bg-muted hover:text-foreground focus:outline-none"
+        >
+          <X size={18} />
+        </button>
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/frontend/src/atoms/Modal/index.ts
+++ b/frontend/src/atoms/Modal/index.ts
@@ -1,0 +1,1 @@
+export * from './Modal';


### PR DESCRIPTION
## Summary
- implement Modal atom with glass variant
- add unit tests and stories
- document in Storybook

## Testing
- `node node_modules/.pnpm/vitest@1.6.1_jsdom@26.1.0/node_modules/vitest/vitest.mjs run` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6870faa24a4c832baa7e5212b82b703c