### PR TITLE
Add Toast atom component

### DIFF
--- a/frontend/src/atoms/Toast/Toast.docs.mdx
+++ b/frontend/src/atoms/Toast/Toast.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Toast } from './Toast';
+
+<Meta title="Atoms/Toast" of={Toast} />
+
+# Toast
+
+The `Toast` component displays brief non-intrusive messages. Use it to confirm actions or show information that doesn't require a full alert.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <Toast>Info message</Toast>
+      <Toast intent="success" className="mt-4">Success message</Toast>
+      <Toast intent="error" className="mt-4">Error message</Toast>
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Toast} />

--- a/frontend/src/atoms/Toast/Toast.stories.tsx
+++ b/frontend/src/atoms/Toast/Toast.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Toast, ToastProps } from './Toast';
+
+const meta: Meta<ToastProps> = {
+  title: 'Atoms/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  argTypes: {
+    intent: { control: 'select', options: ['info', 'success', 'error'] },
+    position: {
+      control: 'select',
+      options: ['top-right', 'top-left', 'bottom-right', 'bottom-left'],
+    },
+    duration: { control: 'number' },
+    showClose: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: 'This is a toast message' },
+};
+
+export const Success: Story = {
+  args: { intent: 'success', children: 'Saved successfully!' },
+};
+
+export const Error: Story = {
+  args: { intent: 'error', children: 'Something went wrong' },
+};

--- a/frontend/src/atoms/Toast/Toast.test.tsx
+++ b/frontend/src/atoms/Toast/Toast.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Toast } from './Toast';
+
+describe('Toast', () => {
+  it('renders message and intent classes', () => {
+    render(<Toast intent="success">Saved!</Toast>);
+    const toast = screen.getByRole('status');
+    expect(toast).toHaveTextContent('Saved!');
+    expect(toast.className).toContain('bg-success');
+  });
+
+  it('calls onDismiss after duration', () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(
+      <Toast intent="info" duration={1000} onDismiss={onDismiss}>
+        Info
+      </Toast>
+    );
+    vi.advanceTimersByTime(1000);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('dismisses when close button clicked', () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast intent="error" onDismiss={onDismiss}>
+        Error
+      </Toast>
+    );
+    const button = screen.getByRole('button', { name: /close/i });
+    button.click();
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/atoms/Toast/Toast.tsx
+++ b/frontend/src/atoms/Toast/Toast.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const toastVariants = cva(
+  'fixed z-50 pointer-events-auto flex items-center gap-2 rounded-md shadow-lg px-4 py-2 text-sm transition-opacity',
+  {
+    variants: {
+      intent: {
+        info: 'bg-secondary text-secondary-foreground',
+        success: 'bg-success text-success-foreground',
+        error: 'bg-destructive text-destructive-foreground',
+      },
+      position: {
+        'top-right': 'top-4 right-4',
+        'top-left': 'top-4 left-4',
+        'bottom-right': 'bottom-4 right-4',
+        'bottom-left': 'bottom-4 left-4',
+      },
+    },
+    defaultVariants: {
+      intent: 'info',
+      position: 'top-right',
+    },
+  },
+);
+
+export interface ToastProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof toastVariants> {
+  duration?: number;
+  onDismiss?: () => void;
+  showClose?: boolean;
+}
+
+export const Toast: React.FC<ToastProps> = ({
+  className,
+  intent,
+  position,
+  duration = 3000,
+  onDismiss,
+  showClose = true,
+  children,
+  ...props
+}) => {
+  React.useEffect(() => {
+    if (!onDismiss) return;
+    const timer = setTimeout(() => onDismiss(), duration);
+    return () => clearTimeout(timer);
+  }, [onDismiss, duration]);
+
+  return (
+    <div className={cn(toastVariants({ intent, position }), className)} role="status" {...props}>
+      <div className="flex-1">{children}</div>
+      {showClose && onDismiss && (
+        <button onClick={onDismiss} aria-label="Close" className="ml-2">
+          <X size={16} />
+        </button>
+      )}
+    </div>
+  );
+};
+
+Toast.displayName = 'Toast';
+
+export { toastVariants };

--- a/frontend/src/atoms/Toast/index.ts
+++ b/frontend/src/atoms/Toast/index.ts
@@ -1,0 +1,1 @@
+export * from './Toast';


### PR DESCRIPTION
## Summary
- create `Toast` atom with success, error and info intents
- add Storybook stories and documentation
- provide unit tests

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fac4d8f8832b89ceeb7590d62b08