### PR TITLE
Add Spinner story, docs and tests

### DIFF
--- a/frontend/src/atoms/Button/Button.test.tsx
+++ b/frontend/src/atoms/Button/Button.test.tsx
@@ -47,11 +47,10 @@ describe('Button', () => {
     const button = screen.getByRole('button');
     expect(button).toBeDisabled();
 
-    // Check that the spinner is rendered
-    // The spinner is a div, so we can't query by a specific role.
-    // We'll check for its presence by observing the button's children.
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    expect(button.querySelector('.animate-spin')).toBeInTheDocument();
+    // Spinner should be present with an accessible label
+    const spinner = button.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toHaveClass('sr-only');
   });
 
   describe('with icons', () => {

--- a/frontend/src/atoms/Spinner/Spinner.docs.mdx
+++ b/frontend/src/atoms/Spinner/Spinner.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Spinner } from './Spinner';
+
+<Meta title="Atoms/Spinner" of={Spinner} />
+
+# Spinner
+
+The `Spinner` component displays a rotating indicator to signal that content is loading. Adjust its `size` and `intent` props to match the context.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="flex items-center space-x-4">
+      <Spinner />
+      <Spinner size="sm" />
+      <Spinner size="lg" intent="secondary" />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Spinner} />

--- a/frontend/src/atoms/Spinner/Spinner.stories.tsx
+++ b/frontend/src/atoms/Spinner/Spinner.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Spinner, SpinnerProps } from './Spinner';
+
+const meta: Meta<SpinnerProps> = {
+  title: 'Atoms/Spinner',
+  component: Spinner,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    intent: { control: 'select', options: ['primary', 'secondary'] },
+    label: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Small: Story = { args: { size: 'sm' } };
+export const Large: Story = { args: { size: 'lg' } };
+export const Secondary: Story = { args: { intent: 'secondary' } };

--- a/frontend/src/atoms/Spinner/Spinner.test.tsx
+++ b/frontend/src/atoms/Spinner/Spinner.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Spinner } from './Spinner';
+
+describe('Spinner', () => {
+  it('renders with default classes', () => {
+    render(<Spinner />);
+    const spinner = screen.getByRole('status');
+    expect(spinner).toHaveClass('animate-spin');
+  });
+
+  it('applies size variants', () => {
+    const { rerender } = render(<Spinner size="sm" />);
+    let spinner = screen.getByRole('status');
+    expect(spinner).toHaveClass('h-4 w-4');
+
+    rerender(<Spinner size="lg" />);
+    spinner = screen.getByRole('status');
+    expect(spinner).toHaveClass('h-8 w-8');
+  });
+
+  it('renders accessible label', () => {
+    render(<Spinner label="Cargando" />);
+    expect(screen.getByText('Cargando')).toHaveClass('sr-only');
+  });
+});

--- a/frontend/src/atoms/Spinner/Spinner.tsx
+++ b/frontend/src/atoms/Spinner/Spinner.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -19,10 +20,17 @@ const spinnerVariants = cva('animate-spin rounded-full border-4 border-solid', {
   },
 });
 
-export interface SpinnerProps extends VariantProps<typeof spinnerVariants> {
-  className?: string;
+export interface SpinnerProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof spinnerVariants> {
+  /** Screen reader label for accessibility */
+  label?: string;
 }
 
-export function Spinner({ className, intent, size }: SpinnerProps) {
-  return <div className={cn(spinnerVariants({ intent, size }), className)} />;
+export function Spinner({ className, intent, size, label, ...props }: SpinnerProps) {
+  return (
+    <div role="status" className={cn(spinnerVariants({ intent, size }), className)} {...props}>
+      <span className="sr-only">{label ?? 'Loading...'}</span>
+    </div>
+  );
 }

--- a/frontend/src/atoms/Spinner/index.ts
+++ b/frontend/src/atoms/Spinner/index.ts
@@ -1,0 +1,1 @@
+export * from './Spinner';


### PR DESCRIPTION
## Summary
- document Spinner component usage in Storybook
- add Storybook story to showcase Spinner variants
- test Spinner behavior and accessibility
- expose Spinner via index file
- update Button tests for new Spinner label

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6870fadd30f4832b992b429343860084