### PR TITLE
Add ProgressBar atom

### DIFF
--- a/frontend/src/atoms/ProgressBar/ProgressBar.docs.mdx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { ProgressBar } from './ProgressBar';
+
+<Meta title="Atoms/ProgressBar" of={ProgressBar} />
+
+# ProgressBar
+
+Displays the progress of a task. Provide a `value` between 0 and 100 for determinate mode or omit the prop for an indeterminate bar.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <ProgressBar value={75} />
+      <div className="h-4" />
+      <ProgressBar />
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={ProgressBar} />

--- a/frontend/src/atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProgressBar, ProgressBarProps } from './ProgressBar';
+
+const meta: Meta<ProgressBarProps> = {
+  title: 'Atoms/ProgressBar',
+  component: ProgressBar,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: { type: 'number', min: 0, max: 100 } },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    color: { control: 'select', options: ['primary','secondary','tertiary','quaternary','success'] },
+    className: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Determinate: Story = { args: { value: 60 } };
+
+export const Indeterminate: Story = { args: {} };
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <ProgressBar {...args} size="sm" value={50} />
+      <ProgressBar {...args} size="md" value={50} />
+      <ProgressBar {...args} size="lg" value={50} />
+    </div>
+  ),
+  args: {},
+};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <ProgressBar {...args} color="primary" value={70} />
+      <ProgressBar {...args} color="secondary" value={70} />
+      <ProgressBar {...args} color="tertiary" value={70} />
+      <ProgressBar {...args} color="quaternary" value={70} />
+      <ProgressBar {...args} color="success" value={70} />
+    </div>
+  ),
+  args: {},
+};

--- a/frontend/src/atoms/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ProgressBar } from './ProgressBar';
+
+describe('ProgressBar', () => {
+  it('applies width based on value', () => {
+    render(<ProgressBar value={40} />);
+    const indicator = screen.getByRole('progressbar').firstChild as HTMLElement;
+    expect(indicator).toHaveStyle('width: 40%');
+  });
+
+  it('renders indeterminate animation when no value', () => {
+    render(<ProgressBar />);
+    const indicator = screen.getByRole('progressbar').firstChild as HTMLElement;
+    expect(indicator.className).toContain('animate-indeterminate');
+  });
+
+  it('applies size variants', () => {
+    const { rerender } = render(<ProgressBar size="sm" value={10} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveClass('h-1.5');
+
+    rerender(<ProgressBar size="lg" value={10} />);
+    expect(bar).toHaveClass('h-3');
+  });
+});

--- a/frontend/src/atoms/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const trackVariants = cva('w-full bg-muted rounded-full overflow-hidden relative', {
+  variants: {
+    size: {
+      sm: 'h-1.5',
+      md: 'h-2',
+      lg: 'h-3',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+const indicatorVariants = cva('h-full transition-[width] duration-300', {
+  variants: {
+    color: {
+      primary: 'bg-primary',
+      secondary: 'bg-secondary',
+      tertiary: 'bg-tertiary',
+      quaternary: 'bg-quaternary',
+      success: 'bg-success',
+    },
+  },
+  defaultVariants: {
+    color: 'primary',
+  },
+});
+
+export interface ProgressBarProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof trackVariants>,
+    VariantProps<typeof indicatorVariants> {
+  /** Percentage of completion (0-100). Omit for indeterminate state. */
+  value?: number;
+}
+
+export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
+  ({ className, size, color, value, ...props }, ref) => {
+    const clamped = value === undefined ? undefined : Math.min(100, Math.max(0, value));
+    const isIndeterminate = clamped === undefined;
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={isIndeterminate ? undefined : clamped}
+        className={cn(trackVariants({ size }), className)}
+        {...props}
+      >
+        {isIndeterminate ? (
+          <div className={cn(indicatorVariants({ color }), 'animate-indeterminate')} />
+        ) : (
+          <div className={indicatorVariants({ color })} style={{ width: `${clamped}%` }} />
+        )}
+      </div>
+    );
+  },
+);
+ProgressBar.displayName = 'ProgressBar';
+
+export { trackVariants as progressBarTrackVariants, indicatorVariants as progressBarIndicatorVariants };

--- a/frontend/src/atoms/ProgressBar/index.ts
+++ b/frontend/src/atoms/ProgressBar/index.ts
@@ -1,0 +1,1 @@
+export * from './ProgressBar';

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -187,3 +187,13 @@
     --slider-color: var(--success);
   }
 }
+  @keyframes progress-indeterminate {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(100%); }
+  }
+  .animate-indeterminate {
+    position: absolute;
+    left: 0;
+    width: 50%;
+    animation: progress-indeterminate 1s infinite linear;
+  }


### PR DESCRIPTION
## Summary
- implement new `ProgressBar` atom with determinate and indeterminate modes
- document the component in Storybook
- add unit tests
- include animation styles for indeterminate state

## Testing
- `pnpm --dir frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870faed879c832b9847d7a0b261de2e