### PR TITLE
Add Card atom

### DIFF
--- a/frontend/src/atoms/Card/Card.docs.mdx
+++ b/frontend/src/atoms/Card/Card.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Card } from './Card';
+
+<Meta title="Atoms/Card" of={Card} />
+
+# Card
+
+The `Card` component is a simple container used to group related content. Use the `variant` prop to adjust its appearance.
+
+<Canvas>
+  <Story name="Example">
+    <Card>
+      <strong>Title</strong>
+      <p className="mt-2 text-sm text-muted-foreground">Some supporting text.</p>
+    </Card>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Card} />

--- a/frontend/src/atoms/Card/Card.stories.tsx
+++ b/frontend/src/atoms/Card/Card.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card, CardProps } from './Card';
+
+const meta: Meta<CardProps> = {
+  title: 'Atoms/Card',
+  component: Card,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['shadow', 'outline', 'glass'] },
+    clickable: { control: 'boolean' },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: 'Simple card' },
+};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="space-y-4">
+      <Card {...args} variant="outline">Outline card</Card>
+      <Card {...args} variant="shadow">Shadow card</Card>
+      <Card {...args} variant="glass">Glass card</Card>
+    </div>
+  ),
+  args: { clickable: false },
+};
+
+export const Clickable: Story = {
+  args: { clickable: true, children: 'Clickable card' },
+};

--- a/frontend/src/atoms/Card/Card.test.tsx
+++ b/frontend/src/atoms/Card/Card.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Card } from './Card';
+
+describe('Card', () => {
+  it('renders children', () => {
+    render(<Card>content</Card>);
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  it('applies default classes', () => {
+    render(<Card>card</Card>);
+    const card = screen.getByText('card');
+    expect(card).toHaveClass('shadow-md');
+    expect(card).toHaveClass('p-4');
+  });
+
+  it('applies outline variant', () => {
+    render(<Card variant="outline">card</Card>);
+    const card = screen.getByText('card');
+    expect(card).toHaveClass('shadow-none');
+  });
+
+  it('applies glass variant', () => {
+    render(<Card variant="glass">glass</Card>);
+    const card = screen.getByText('glass');
+    expect(card.className).toContain('backdrop-blur-md');
+  });
+
+  it('adds hover effect when clickable', () => {
+    render(
+      <Card clickable data-testid="clickable">
+        hi
+      </Card>
+    );
+    expect(screen.getByTestId('clickable').className).toContain('cursor-pointer');
+  });
+});

--- a/frontend/src/atoms/Card/Card.tsx
+++ b/frontend/src/atoms/Card/Card.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const cardVariants = cva(
+  'rounded-md border border-border bg-white p-4 text-foreground transition-shadow',
+  {
+    variants: {
+      variant: {
+        shadow: 'shadow-md',
+        outline: 'shadow-none',
+        glass: 'bg-surface-glass/80 backdrop-blur-md border-white/20 shadow-glass',
+      },
+      clickable: {
+        true: 'cursor-pointer hover:shadow-lg',
+      },
+    },
+    defaultVariants: {
+      variant: 'shadow',
+    },
+  },
+);
+
+export interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof cardVariants> {
+  clickable?: boolean;
+}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant, clickable, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(cardVariants({ variant, clickable, className }))}
+        {...props}
+      />
+    );
+  },
+);
+Card.displayName = 'Card';
+
+export { cardVariants };

--- a/frontend/src/atoms/Card/index.ts
+++ b/frontend/src/atoms/Card/index.ts
@@ -1,0 +1,1 @@
+export * from './Card';


### PR DESCRIPTION
## Summary
- introduce Card atom with cva style variants
- document Card in Storybook via MDX and stories
- provide basic tests for Card

## Testing
- `pnpm --filter frontend test` *(fails: No projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_6870fafb78fc832ba54af3d308062b72