### PR TITLE
Add Accordion atom component

### DIFF
--- a/frontend/src/atoms/Accordion/Accordion.docs.mdx
+++ b/frontend/src/atoms/Accordion/Accordion.docs.mdx
@@ -1,0 +1,18 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Accordion } from './Accordion';
+
+<Meta title="Atoms/Accordion" of={Accordion} />
+
+# Accordion
+
+The `Accordion` component reveals or hides additional content when its header is clicked. It is useful for FAQs, filter sections or any collapsible information.
+
+<Canvas>
+  <Story name="Example">
+    <Accordion title="Customer Details">
+      Here goes additional information about the customer.
+    </Accordion>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Accordion} />

--- a/frontend/src/atoms/Accordion/Accordion.stories.tsx
+++ b/frontend/src/atoms/Accordion/Accordion.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Accordion, AccordionProps } from './Accordion';
+
+const meta: Meta<AccordionProps> = {
+  title: 'Atoms/Accordion',
+  component: Accordion,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    defaultOpen: { control: 'boolean' },
+    open: { control: false },
+    onToggle: { action: 'toggle' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Section title',
+    children: 'Hidden content here',
+  },
+};
+
+export const Open: Story = {
+  args: {
+    title: 'Initially open',
+    defaultOpen: true,
+    children: 'Content visible by default',
+  },
+};
+
+export const Colors: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <Accordion {...args} color="primary" title="Primary">
+        Content primary
+      </Accordion>
+      <Accordion {...args} color="secondary" title="Secondary">
+        Content secondary
+      </Accordion>
+      <Accordion {...args} color="tertiary" title="Tertiary">
+        Content tertiary
+      </Accordion>
+      <Accordion {...args} color="quaternary" title="Quaternary">
+        Content quaternary
+      </Accordion>
+      <Accordion {...args} color="success" title="Success">
+        Content success
+      </Accordion>
+    </div>
+  ),
+  args: {
+    defaultOpen: false,
+    children: '...',
+  },
+};

--- a/frontend/src/atoms/Accordion/Accordion.test.tsx
+++ b/frontend/src/atoms/Accordion/Accordion.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Accordion } from './Accordion';
+
+describe('Accordion', () => {
+  it('renders title and children', () => {
+    render(<Accordion title="Title">Content</Accordion>);
+    expect(screen.getByText('Title')).toBeInTheDocument();
+  });
+
+  it('hides content when closed', () => {
+    render(<Accordion title="Title">Hidden</Accordion>);
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+
+  it('shows content when open', () => {
+    render(
+      <Accordion title="Title" defaultOpen>
+        Visible
+      </Accordion>,
+    );
+    expect(screen.getByText('Visible')).toBeInTheDocument();
+  });
+
+  it('toggles on header click', () => {
+    const onToggle = vi.fn();
+    render(
+      <Accordion title="Title" onToggle={onToggle}>
+        Toggle
+      </Accordion>,
+    );
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(onToggle).toHaveBeenCalledWith(true);
+    fireEvent.click(button);
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('sets aria attributes correctly', () => {
+    render(<Accordion title="A" defaultOpen>Content</Accordion>);
+    const button = screen.getByRole('button');
+    const region = screen.getByRole('region');
+    expect(button).toHaveAttribute('aria-controls', region.id);
+    expect(region).toHaveAttribute('aria-labelledby', button.id);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/frontend/src/atoms/Accordion/Accordion.tsx
+++ b/frontend/src/atoms/Accordion/Accordion.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const headerVariants = cva(
+  "flex w-full items-center justify-between py-2 text-left font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary",
+  {
+    variants: {
+      color: {
+        primary: "text-primary",
+        secondary: "text-secondary",
+        tertiary: "text-tertiary",
+        quaternary: "text-quaternary",
+        success: "text-success",
+      },
+    },
+    defaultVariants: {
+      color: "primary",
+    },
+  },
+);
+
+export interface AccordionProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "color">,
+    VariantProps<typeof headerVariants> {
+  /** Header text or node */
+  title: React.ReactNode;
+  /** Controlled open state */
+  open?: boolean;
+  /** Initial open state when uncontrolled */
+  defaultOpen?: boolean;
+  /** Callback when toggled */
+  onToggle?: (open: boolean) => void;
+}
+
+export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
+  (
+    {
+      className,
+      title,
+      children,
+      color,
+      open,
+      defaultOpen = false,
+      onToggle,
+      ...props
+    },
+    ref,
+  ) => {
+    const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+    const isControlled = open !== undefined;
+    const isOpen = isControlled ? open : internalOpen;
+
+    const handleToggle = () => {
+      if (!isControlled) setInternalOpen(!isOpen);
+      onToggle?.(!isOpen);
+    };
+
+    const contentId = React.useId();
+    const headerId = React.useId();
+
+    return (
+      <div ref={ref} className={cn("border-b border-border", className)} {...props}>
+        <button
+          type="button"
+          id={headerId}
+          aria-controls={contentId}
+          aria-expanded={isOpen}
+          onClick={handleToggle}
+          className={cn(headerVariants({ color }))}
+        >
+          <span>{title}</span>
+          <ChevronDown
+            size={16}
+            className={cn("transition-transform", isOpen && "rotate-180")}
+          />
+        </button>
+        <div
+          id={contentId}
+          role="region"
+          aria-labelledby={headerId}
+          className={cn("pt-1 pb-2 text-sm", !isOpen && "hidden")}
+        >
+          {children}
+        </div>
+      </div>
+    );
+  },
+);
+Accordion.displayName = "Accordion";
+
+export { headerVariants as accordionHeaderVariants };

--- a/frontend/src/atoms/Accordion/index.ts
+++ b/frontend/src/atoms/Accordion/index.ts
@@ -1,0 +1,1 @@
+export * from './Accordion';


### PR DESCRIPTION
## Summary
- create Accordion atom with basic toggle behavior
- add Storybook stories and docs entry
- add unit tests for Accordion

## Testing
- `node ../node_modules/.pnpm/vitest@*/node_modules/vitest/vitest.mjs run` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb0ed118832b9cac72b2d16070ae