### PR TITLE
Add Table atom

### DIFF
--- a/frontend/src/atoms/Table/Table.docs.mdx
+++ b/frontend/src/atoms/Table/Table.docs.mdx
@@ -1,0 +1,36 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Table } from './Table';
+
+<Meta title="Atoms/Table" of={Table} />
+
+# Table
+
+The `Table` component applies consistent styles to HTML tables. Use the `variant`, `size`, and `color` props to control the appearance.
+
+<Canvas>
+  <Story name="Example">
+    <Table caption="Sample data">
+      <thead>
+        <tr>
+          <th>Producto</th>
+          <th>Stock</th>
+          <th>Precio</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Camiseta</td>
+          <td>25</td>
+          <td>$12</td>
+        </tr>
+        <tr>
+          <td>Pantalón</td>
+          <td>10</td>
+          <td>$25</td>
+        </tr>
+      </tbody>
+    </Table>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Table} />

--- a/frontend/src/atoms/Table/Table.stories.tsx
+++ b/frontend/src/atoms/Table/Table.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Table, TableProps } from './Table';
+
+const meta: Meta<TableProps> = {
+  title: 'Atoms/Table',
+  component: Table,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['simple', 'striped'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    color: {
+      control: 'select',
+      options: ['muted', 'primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    caption: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    caption: 'Example inventory table',
+    children: (
+      <>
+        <thead>
+          <tr>
+            <th>Producto</th>
+            <th>Stock</th>
+            <th>Precio</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Camiseta</td>
+            <td>25</td>
+            <td>$12</td>
+          </tr>
+          <tr>
+            <td>Pantalón</td>
+            <td>10</td>
+            <td>$25</td>
+          </tr>
+        </tbody>
+      </>
+    ),
+  },
+};
+
+export const Striped: Story = {
+  args: {
+    variant: 'striped',
+    children: (
+      <>
+        <thead>
+          <tr>
+            <th>Cliente</th>
+            <th>Correo</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Ana</td>
+            <td>ana@example.com</td>
+          </tr>
+          <tr>
+            <td>Juan</td>
+            <td>juan@example.com</td>
+          </tr>
+        </tbody>
+      </>
+    ),
+  },
+};

--- a/frontend/src/atoms/Table/Table.test.tsx
+++ b/frontend/src/atoms/Table/Table.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Table } from './Table';
+
+const basicTable = (
+  <Table>
+    <thead>
+      <tr>
+        <th>Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Ana</td>
+      </tr>
+    </tbody>
+  </Table>
+);
+
+describe('Table', () => {
+  it('renders a table element', () => {
+    render(basicTable);
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('applies striped variant classes', () => {
+    render(
+      <Table variant="striped">
+        <tbody>
+          <tr><td>1</td></tr>
+        </tbody>
+      </Table>,
+    );
+    const table = screen.getByRole('table');
+    expect(table.className).toContain('nth-child(even)');
+  });
+
+  it('renders caption when provided', () => {
+    render(
+      <Table caption="info">
+        <tbody></tbody>
+      </Table>
+    );
+    expect(screen.getByText('info')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/atoms/Table/Table.tsx
+++ b/frontend/src/atoms/Table/Table.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const tableVariants = cva(
+  'w-full caption-bottom text-sm text-left border-collapse text-foreground [&_th]:border-b [&_th]:text-left [&_th]:font-semibold [&_th]:px-3 [&_td]:px-3 [&_td]:py-2 [&_th]:py-2 [&_td]:border-b [&_tr:last-child_>_td]:border-0',
+  {
+    variants: {
+      variant: {
+        simple: '',
+        striped: '[&_tbody_tr:nth-child(even)]:bg-muted',
+      },
+      size: {
+        sm: '[&_th]:py-1 [&_td]:py-1',
+        md: '[&_th]:py-2 [&_td]:py-2',
+        lg: '[&_th]:py-3 [&_td]:py-3',
+      },
+      color: {
+        muted: '[&_th]:bg-muted',
+        primary: '[&_th]:bg-primary [&_th]:text-primary-foreground',
+        secondary: '[&_th]:bg-secondary [&_th]:text-secondary-foreground',
+        tertiary: '[&_th]:bg-tertiary [&_th]:text-tertiary-foreground',
+        quaternary: '[&_th]:bg-quaternary [&_th]:text-quaternary-foreground',
+        success: '[&_th]:bg-success [&_th]:text-success-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'simple',
+      size: 'md',
+      color: 'muted',
+    },
+  },
+);
+
+export interface TableProps
+  extends React.HTMLAttributes<HTMLTableElement>,
+    VariantProps<typeof tableVariants> {
+  /** Caption for the table, placed below */
+  caption?: string;
+}
+
+export const Table = React.forwardRef<HTMLTableElement, TableProps>(
+  ({ className, variant, size, color, caption, children, ...props }, ref) => (
+    <table ref={ref} className={cn(tableVariants({ variant, size, color }), className)} {...props}>
+      {children}
+      {caption && <caption className="mt-2 text-sm text-muted-foreground">{caption}</caption>}
+    </table>
+  ),
+);
+Table.displayName = 'Table';
+
+export { tableVariants };

--- a/frontend/src/atoms/Table/index.ts
+++ b/frontend/src/atoms/Table/index.ts
@@ -1,0 +1,1 @@
+export * from './Table';


### PR DESCRIPTION
## Summary
- add Table atom for data tables
- provide Storybook stories, docs, and tests

## Testing
- `pnpm --filter erp_system exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb1e57a0832b8c1cd361c55cf36b