### PR TITLE
Add Tabs atom

### DIFF
--- a/frontend/src/atoms/Tabs/Tabs.docs.mdx
+++ b/frontend/src/atoms/Tabs/Tabs.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Tabs } from './Tabs';
+
+<Meta title="Atoms/Tabs" of={Tabs} />
+
+# Tabs
+
+Use `Tabs` to switch between related sections of content without reloading the page.
+
+<Canvas>
+  <Story name="Ejemplo">
+    <Tabs items={[{ label: 'Uno', content: <p>Contenido uno</p> }, { label: 'Dos', content: <p>Contenido dos</p> }]} />
+  </Story>
+</Canvas>
+
+<ArgsTable of={Tabs} />

--- a/frontend/src/atoms/Tabs/Tabs.stories.tsx
+++ b/frontend/src/atoms/Tabs/Tabs.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Tabs, TabsProps } from './Tabs';
+
+const exampleItems = [
+  { label: 'Perfil', content: <p>Contenido del perfil</p> },
+  { label: 'Actividad', content: <p>Historial del usuario</p> },
+  { label: 'Ajustes', content: <p>Configuraci\u00f3n de la cuenta</p> },
+];
+
+const meta: Meta<TabsProps> = {
+  title: 'Atoms/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['underline', 'solid'] },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    orientation: { control: 'select', options: ['horizontal', 'vertical'] },
+    defaultIndex: { control: 'number' },
+  },
+  args: { items: exampleItems },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Solid: Story = {
+  args: { variant: 'solid', color: 'secondary' },
+};
+
+export const Vertical: Story = {
+  args: { orientation: 'vertical', defaultIndex: 1 },
+};

--- a/frontend/src/atoms/Tabs/Tabs.test.tsx
+++ b/frontend/src/atoms/Tabs/Tabs.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { Tabs, TabItem } from './Tabs';
+
+describe('Tabs', () => {
+  const items: TabItem[] = [
+    { label: 'One', content: <div>First</div> },
+    { label: 'Two', content: <div>Second</div> },
+    { label: 'Three', content: <div>Third</div> },
+  ];
+
+  it('renders all tab buttons', () => {
+    render(<Tabs items={items} />);
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+  });
+
+  it('changes content when a tab is clicked', () => {
+    render(<Tabs items={items} />);
+    fireEvent.click(screen.getByText('Two'));
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+
+  it('sets aria-selected correctly', () => {
+    render(<Tabs items={items} defaultIndex={1} />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('navigates with arrow keys', async () => {
+    const user = userEvent.setup();
+    render(<Tabs items={items} />);
+    const tabs = screen.getAllByRole('tab');
+    tabs[0].focus();
+    await user.keyboard('{arrowright}');
+    expect(tabs[1]).toHaveFocus();
+  });
+});

--- a/frontend/src/atoms/Tabs/Tabs.tsx
+++ b/frontend/src/atoms/Tabs/Tabs.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type TabsColor = 'primary' | 'secondary' | 'tertiary' | 'quaternary' | 'success';
+export type TabsVariant = 'underline' | 'solid';
+export type TabsOrientation = 'horizontal' | 'vertical';
+
+export interface TabItem {
+  label: React.ReactNode;
+  content: React.ReactNode;
+  id?: string;
+}
+
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+  items: TabItem[];
+  defaultIndex?: number;
+  variant?: TabsVariant;
+  color?: TabsColor;
+  orientation?: TabsOrientation;
+}
+
+const colorClasses: Record<TabsColor, { underline: string; solid: string }> = {
+  primary: {
+    underline: 'data-[active=true]:border-primary data-[active=true]:text-primary',
+    solid: 'data-[active=true]:bg-primary data-[active=true]:text-primary-foreground',
+  },
+  secondary: {
+    underline: 'data-[active=true]:border-secondary data-[active=true]:text-secondary',
+    solid: 'data-[active=true]:bg-secondary data-[active=true]:text-secondary-foreground',
+  },
+  tertiary: {
+    underline: 'data-[active=true]:border-tertiary data-[active=true]:text-tertiary',
+    solid: 'data-[active=true]:bg-tertiary data-[active=true]:text-tertiary-foreground',
+  },
+  quaternary: {
+    underline: 'data-[active=true]:border-quaternary data-[active=true]:text-quaternary',
+    solid: 'data-[active=true]:bg-quaternary data-[active=true]:text-quaternary-foreground',
+  },
+  success: {
+    underline: 'data-[active=true]:border-success data-[active=true]:text-success',
+    solid: 'data-[active=true]:bg-success data-[active=true]:text-success-foreground',
+  },
+};
+
+export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
+  (
+    {
+      items,
+      defaultIndex = 0,
+      variant = 'underline',
+      color = 'primary',
+      orientation = 'horizontal',
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const [active, setActive] = React.useState(defaultIndex);
+    const tabRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const key = e.key;
+      if (!['ArrowRight','ArrowLeft','ArrowDown','ArrowUp'].includes(key)) return;
+      e.preventDefault();
+      const dir = key === 'ArrowRight' || key === 'ArrowDown' ? 1 : -1;
+      const next = (active + dir + items.length) % items.length;
+      tabRefs.current[next]?.focus();
+      setActive(next);
+    };
+
+    const orientationClasses = orientation === 'vertical' ? 'flex flex-row' : 'flex flex-col';
+    const listClasses = orientation === 'vertical' ? 'flex flex-col border-r' : 'flex border-b';
+    const panelClasses = orientation === 'vertical' ? 'flex-1 p-4' : 'p-4';
+
+    return (
+      <div ref={ref} className={cn(orientationClasses, className)} {...props}>
+        <div role="tablist" aria-orientation={orientation} onKeyDown={handleKeyDown} className={listClasses}>
+          {items.map((item, index) => {
+            const id = item.id ?? `tab-${index}`;
+            const panelId = `${id}-panel`;
+            return (
+              <button
+                key={id}
+                id={id}
+                ref={(el) => (tabRefs.current[index] = el)}
+                role="tab"
+                type="button"
+                data-active={active === index}
+                aria-selected={active === index}
+                aria-controls={panelId}
+                className={cn(
+                  'px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary',
+                  variant === 'underline' ? 'border-b-2 border-transparent' : 'rounded-md',
+                  colorClasses[color][variant],
+                  active === index ? '' : 'text-muted-foreground',
+                )}
+                onClick={() => setActive(index)}
+              >
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+        <div className={panelClasses}>
+          {items.map((item, index) => {
+            const id = item.id ?? `tab-${index}`;
+            const panelId = `${id}-panel`;
+            return (
+              <div
+                key={panelId}
+                id={panelId}
+                role="tabpanel"
+                aria-labelledby={id}
+                hidden={active !== index}
+              >
+                {item.content}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  },
+);
+Tabs.displayName = 'Tabs';
+
+export type { TabItem };

--- a/frontend/src/atoms/Tabs/index.ts
+++ b/frontend/src/atoms/Tabs/index.ts
@@ -1,0 +1,1 @@
+export * from './Tabs';


### PR DESCRIPTION
## Summary
- implement new Tabs atom component with color, variant and orientation support
- document Tabs usage in Storybook
- add stories for default, solid, and vertical layouts
- provide unit tests for basic behavior

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb32d4e0832bbebf81ac28ff234f