### PR TITLE
Add FileUpload atom

### DIFF
--- a/frontend/src/atoms/FileUpload/FileUpload.docs.mdx
+++ b/frontend/src/atoms/FileUpload/FileUpload.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { FileUpload } from './FileUpload';
+
+<Meta title="Atoms/FileUpload" of={FileUpload} />
+
+# FileUpload
+
+The `FileUpload` component enhances the default file input by hiding the native field and presenting a styled button. After selecting a file it displays the file name or, when `multiple` is enabled, the number of selected files.
+
+<Canvas>
+  <Story name="Examples">
+    <>
+      <FileUpload />
+      <br />
+      <FileUpload multiple buttonText="Subir archivos" />
+    </>
+  </Story>
+</Canvas>
+
+<ArgsTable of={FileUpload} />

--- a/frontend/src/atoms/FileUpload/FileUpload.stories.tsx
+++ b/frontend/src/atoms/FileUpload/FileUpload.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FileUpload, FileUploadProps } from './FileUpload';
+
+const meta: Meta<FileUploadProps> = {
+  title: 'Atoms/FileUpload',
+  component: FileUpload,
+  tags: ['autodocs'],
+  argTypes: {
+    buttonText: { control: 'text' },
+    multiple: { control: 'boolean' },
+    intent: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'outline', 'ghost', 'glass', 'icon'],
+    },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    onChange: { action: 'changed', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Multiple: Story = {
+  args: { multiple: true },
+};

--- a/frontend/src/atoms/FileUpload/FileUpload.test.tsx
+++ b/frontend/src/atoms/FileUpload/FileUpload.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FileUpload } from './FileUpload';
+
+const createFile = (name: string) => new File(['hello'], name, { type: 'text/plain' });
+
+describe('FileUpload', () => {
+  it('renders trigger button', () => {
+    render(<FileUpload />);
+    expect(screen.getByRole('button', { name: /seleccionar archivo/i })).toBeInTheDocument();
+  });
+
+  it('displays selected file name', () => {
+    render(<FileUpload />);
+    const input = screen.getByLabelText(/seleccionar archivo/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('test.txt')] } });
+    expect(screen.getByText('test.txt')).toBeInTheDocument();
+  });
+
+  it('shows count when multiple files selected', () => {
+    render(<FileUpload multiple />);
+    const input = screen.getByLabelText(/seleccionar archivo/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('a.txt'), createFile('b.txt')] } });
+    expect(screen.getByText('2 archivos seleccionados')).toBeInTheDocument();
+  });
+
+  it('calls onChange handler', () => {
+    const handleChange = vi.fn();
+    render(<FileUpload onChange={handleChange} />);
+    const input = screen.getByLabelText(/seleccionar archivo/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('file.pdf')] } });
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/atoms/FileUpload/FileUpload.tsx
+++ b/frontend/src/atoms/FileUpload/FileUpload.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { VariantProps } from 'class-variance-authority';
+
+import { Button, buttonVariants, ButtonProps } from '@/atoms/Button/Button';
+import { cn } from '@/lib/utils';
+
+export interface FileUploadProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'>,
+    Pick<ButtonProps, 'intent' | 'variant' | 'size'> {
+  /** Text shown on the trigger button */
+  buttonText?: string;
+}
+
+export const FileUpload = React.forwardRef<HTMLInputElement, FileUploadProps>(
+  (
+    {
+      buttonText = 'Seleccionar archivo',
+      className,
+      intent = 'secondary',
+      variant = 'outline',
+      size = 'md',
+      multiple,
+      onChange,
+      ...props
+    },
+    ref,
+  ) => {
+    const [fileLabel, setFileLabel] = React.useState('');
+    const inputId = React.useId();
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      const files = Array.from(e.target.files ?? []);
+      setFileLabel(
+        files.length === 0
+          ? ''
+          : multiple && files.length > 1
+          ? `${files.length} archivos seleccionados`
+          : files[0].name,
+      );
+      onChange?.(e);
+    };
+
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          id={inputId}
+          type="file"
+          multiple={multiple}
+          ref={ref}
+          onChange={handleChange}
+          className="hidden"
+          {...props}
+        />
+        <label htmlFor={inputId} className="shrink-0">
+          <Button type="button" intent={intent} variant={variant} size={size}>
+            {buttonText}
+          </Button>
+        </label>
+        <span className={cn('text-sm text-muted-foreground', className)}>
+          {fileLabel || 'Ningún archivo seleccionado'}
+        </span>
+      </div>
+    );
+  },
+);
+FileUpload.displayName = 'FileUpload';
+
+export { FileUpload };

--- a/frontend/src/atoms/FileUpload/index.ts
+++ b/frontend/src/atoms/FileUpload/index.ts
@@ -1,0 +1,1 @@
+export * from './FileUpload';


### PR DESCRIPTION
## Summary
- add FileUpload atom component
- document FileUpload usage and props
- add Storybook stories for FileUpload
- add FileUpload unit tests

## Testing
- `pnpm --workspace-root --filter ./frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb48cce0832bb957063c19c88d56