### PR TITLE
Improve Input label animation and tests

### DIFF
--- a/frontend/src/atoms/Input/Input.stories.tsx
+++ b/frontend/src/atoms/Input/Input.stories.tsx
@@ -69,12 +69,12 @@ const meta: Meta<InputStoryProps> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = { args: { placeholder: "Enter text" } };
+export const Default: Story = { args: { label: "Name", placeholder: "Enter text" } };
 export const WithError: Story = {
-  args: { placeholder: "Invalid", error: true },
+  args: { label: "Email", placeholder: "Invalid", error: true },
 };
 export const Disabled: Story = {
-  args: { placeholder: "Disabled", disabled: true },
+  args: { label: "Disabled", placeholder: "Disabled", disabled: true },
 };
 export const Small: Story = { args: { size: "sm", placeholder: "Small size" } };
 export const Large: Story = { args: { size: "lg", placeholder: "Large size" } };
@@ -87,6 +87,7 @@ export const WithCounter: Story = {
 
 export const SearchBar: Story = {
   args: {
+    label: "Buscar",
     placeholder: "Buscar...",
     leftIconName: "Search",
     color: "primary",
@@ -95,6 +96,7 @@ export const SearchBar: Story = {
 
 export const WithUploadButton: Story = {
   args: {
+    label: "Documento",
     placeholder: "Subir documento",
     rightButtonName: "Upload",
     color: "secondary",
@@ -103,6 +105,7 @@ export const WithUploadButton: Story = {
 
 export const WithRecordButton: Story = {
   args: {
+    label: "Audio",
     placeholder: "Grabar audio",
     rightButtonName: "Mic",
     color: "secondary",

--- a/frontend/src/atoms/Input/Input.test.tsx
+++ b/frontend/src/atoms/Input/Input.test.tsx
@@ -52,6 +52,13 @@ describe('Input', () => {
     expect(screen.getByText('Email')).toHaveAttribute('for', 'email');
   });
 
+  it('positions label correctly with left icon', () => {
+    const LeftIcon = () => <svg data-testid="icon" />;
+    render(<Input label="User" LeftIcon={LeftIcon} />);
+    const label = screen.getByText('User');
+    expect(label.className).toContain('left-10');
+  });
+
   it('shows character count', () => {
     render(<Input showCharCount label="Bio" maxLength={10} />);
     const input = screen.getByLabelText('Bio');

--- a/frontend/src/atoms/Input/Input.tsx
+++ b/frontend/src/atoms/Input/Input.tsx
@@ -103,6 +103,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     };
     const iconFocusColor = color ? iconFocusMap[color] : "";
 
+    const labelLeft = hasLeft ? "left-10" : "left-3";
+
     return (
       <div className="relative group">
         {LeftIcon && (
@@ -138,7 +140,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <label
             htmlFor={inputId}
             className={cn(
-              "pointer-events-none absolute left-3 top-2 text-xs text-muted-foreground transition-all",
+              "pointer-events-none absolute top-2 text-xs text-muted-foreground transition-all",
+              labelLeft,
               "peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2",
               "peer-focus:top-0 peer-focus:-translate-y-[1.2rem]",
             )}


### PR DESCRIPTION
## Summary
- allow floating label with icons in Input
- add tests for label positioning
- update storybook examples to show labels

## Testing
- `pnpm --filter ./frontend test --run src/atoms/Input/Input.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6879048ef3d0832baf9460be35fc95cc