### PR TITLE
Fix Radio atom interaction

### DIFF
--- a/frontend/src/atoms/Radio/Radio.stories.tsx
+++ b/frontend/src/atoms/Radio/Radio.stories.tsx
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj, StoryFn } from '@storybook/react';
 import { useState } from 'react';
-import { Radio } from './Radio';
+import { Radio, type RadioProps } from './Radio';
 
 const meta: Meta<typeof Radio> = {
   title: 'Atoms/Radio',
@@ -21,7 +21,21 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const Template: StoryFn<RadioProps> = (args) => {
+  const [checked, setChecked] = useState(
+    args.defaultChecked ?? args.checked ?? false,
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.target.checked);
+    args.onChange?.(e);
+  };
+
+  return <Radio {...args} checked={checked} onChange={handleChange} />;
+};
+
 export const Default: Story = {
+  render: Template,
   args: {
     name: 'choice',
     label: 'Option',
@@ -31,6 +45,7 @@ export const Default: Story = {
 };
 
 export const Selected: Story = {
+  render: Template,
   args: {
     name: 'choice',
     label: 'Selected',
@@ -41,6 +56,7 @@ export const Selected: Story = {
 };
 
 export const Disabled: Story = {
+  render: Template,
   args: {
     name: 'choice',
     label: 'Disabled',
@@ -51,6 +67,7 @@ export const Disabled: Story = {
 };
 
 export const Large: Story = {
+  render: Template,
   args: {
     name: 'choice',
     label: 'Large',
@@ -60,6 +77,7 @@ export const Large: Story = {
 };
 
 export const Small: Story = {
+  render: Template,
   args: {
     name: 'choice',
     label: 'Small',

--- a/frontend/src/atoms/Radio/Radio.test.tsx
+++ b/frontend/src/atoms/Radio/Radio.test.tsx
@@ -40,4 +40,21 @@ describe('Radio', () => {
     const radio = screen.getByRole('radio');
     expect(radio).toBeDisabled();
   });
+
+  it('supports defaultChecked', () => {
+    render(<Radio label="Default" defaultChecked />);
+    const radio = screen.getByRole('radio');
+    expect(radio).toBeChecked();
+  });
+
+  it('respects controlled checked prop', () => {
+    const { rerender } = render(
+      <Radio label="Ctrl" checked={false} onChange={() => {}} />,
+    );
+    const radio = screen.getByRole('radio');
+    expect(radio).not.toBeChecked();
+
+    rerender(<Radio label="Ctrl" checked onChange={() => {}} />);
+    expect(radio).toBeChecked();
+  });
 });

--- a/frontend/src/atoms/Radio/Radio.tsx
+++ b/frontend/src/atoms/Radio/Radio.tsx
@@ -40,19 +40,22 @@ export interface RadioProps
 }
 
 const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
-  ({ className, size, intent = 'primary', label, children, id, checked, onChange, ...props }, ref) => {
+  (
+    {
+      className,
+      size,
+      intent = 'primary',
+      label,
+      children,
+      id,
+      checked,
+      defaultChecked,
+      onChange,
+      ...props
+    },
+    ref,
+  ) => {
     const inputId = id ?? React.useId();
-
-    const handleClick: React.MouseEventHandler<HTMLInputElement> = (e) => {
-      if (checked) {
-        e.preventDefault();
-        const syntheticEvent = {
-          ...e,
-          target: { ...e.target, checked: false },
-        } as unknown as React.ChangeEvent<HTMLInputElement>;
-        onChange?.(syntheticEvent);
-      }
-    };
 
     return (
       <label
@@ -61,36 +64,25 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
           'opacity-50 cursor-not-allowed': props.disabled,
         })}
       >
-        <span
-          className={cn(
-            'relative inline-flex items-center justify-center',
-            'border border-border rounded-full transition-colors',
-            {
-              'h-4 w-4': size === 'sm',
-              'h-5 w-5': size === 'md',
-              'h-6 w-6': size === 'lg',
-              'border-primary': checked && intent === 'primary',
-              'border-secondary': checked && intent === 'secondary',
-              'border-tertiary': checked && intent === 'tertiary',
-              'border-quaternary': checked && intent === 'quaternary',
-              'border-success': checked && intent === 'success',
-            },
-          )}
-        >
+        <div className="relative inline-flex items-center justify-center">
           <input
             ref={ref}
             id={inputId}
             type="radio"
             checked={checked}
+            defaultChecked={defaultChecked}
             onChange={onChange}
-            onClick={handleClick}
-            className={cn('absolute inset-0 w-full h-full cursor-pointer opacity-0', className)}
+            className={cn(
+              radioVariants({ size, intent }),
+              'peer',
+              className,
+            )}
             {...props}
           />
           {/* Inner dot */}
           <span
             className={cn(
-              'rounded-full transition-all',
+              'pointer-events-none absolute rounded-full transition-opacity',
               {
                 'h-2 w-2': size === 'sm', // 8px
                 'h-2.5 w-2.5': size === 'md', // 10px
@@ -101,10 +93,10 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
                 'bg-quaternary': intent === 'quaternary',
                 'bg-success': intent === 'success',
               },
-              checked ? 'opacity-100' : 'opacity-0',
+              'opacity-0 peer-checked:opacity-100',
             )}
           />
-        </span>
+        </div>
         {label && <span className="text-sm">{label}</span>}
         {!label && children}
       </label>


### PR DESCRIPTION
## Summary
- make radio atom respond to clicks using CSS `peer` approach
- update Radio tests for defaultChecked and controlled usage
- improve storybook stories with interactive template

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687904d031f8832ba2f65555dd04ef5e