### PR TITLE
Improve slider indicator color

### DIFF
--- a/frontend/src/atoms/Slider/Slider.stories.tsx
+++ b/frontend/src/atoms/Slider/Slider.stories.tsx
@@ -75,4 +75,12 @@ export const WithIndicator: Story = {
     );
   },
   args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The indicator adopts the slider color and automatically uses a contrasting text color.',
+      },
+    },
+  },
 };

--- a/frontend/src/atoms/Slider/Slider.test.tsx
+++ b/frontend/src/atoms/Slider/Slider.test.tsx
@@ -33,7 +33,10 @@ describe('Slider', () => {
     render(<Slider defaultValue={20} />);
     const slider = screen.getByRole('slider');
     fireEvent.pointerDown(slider);
-    expect(screen.getByTestId('slider-indicator')).toBeInTheDocument();
+    const indicator = screen.getByTestId('slider-indicator');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.style.backgroundColor).toBe('hsl(var(--slider-color))');
+    expect(indicator.style.color).toBe('hsl(var(--slider-foreground))');
     fireEvent.pointerUp(slider);
     expect(screen.queryByTestId('slider-indicator')).not.toBeInTheDocument();
   });

--- a/frontend/src/atoms/Slider/Slider.tsx
+++ b/frontend/src/atoms/Slider/Slider.tsx
@@ -113,8 +113,12 @@ export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
         {showTip && (
           <span
             data-testid="slider-indicator"
-            className="pointer-events-none absolute -top-6 -translate-x-1/2 rounded bg-gray-700 px-1 py-0.5 text-xs text-white"
-            style={{ left: `${percentage}%` }}
+            className="pointer-events-none absolute -top-6 -translate-x-1/2 rounded px-1 py-0.5 text-xs"
+            style={{
+              left: `${percentage}%`,
+              backgroundColor: "hsl(var(--slider-color))",
+              color: "hsl(var(--slider-foreground))",
+            }}
           >
             {internal}
           </span>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -130,11 +130,12 @@
 
 @layer components {
   .slider {
-    @apply appearance-none w-full cursor-pointer rounded-full bg-muted disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply appearance-none w-full cursor-pointer rounded-full bg-muted disabled:opacity-50 disabled:cursor-not-allowed shadow-inner;
     height: var(--slider-track-height, 0.375rem);
     background-image: linear-gradient(hsl(var(--slider-color, var(--primary))), hsl(var(--slider-color, var(--primary))));
     background-repeat: no-repeat;
     background-size: var(--slider-percentage, 0%) 100%;
+    --slider-foreground: var(--primary-foreground);
   }
   .slider::-webkit-slider-thumb {
     @apply appearance-none rounded-full border-none;
@@ -173,18 +174,23 @@
   }
   .slider-primary {
     --slider-color: var(--primary);
+    --slider-foreground: var(--primary-foreground);
   }
   .slider-secondary {
     --slider-color: var(--secondary);
+    --slider-foreground: var(--secondary-foreground);
   }
   .slider-tertiary {
     --slider-color: var(--tertiary);
+    --slider-foreground: var(--tertiary-foreground);
   }
   .slider-quaternary {
     --slider-color: var(--quaternary);
+    --slider-foreground: var(--quaternary-foreground);
   }
   .slider-success {
     --slider-color: var(--success);
+    --slider-foreground: var(--success-foreground);
   }
 }
   @keyframes progress-indeterminate {


### PR DESCRIPTION
## Summary
- set `--slider-foreground` for slider color variants
- use slider colors for the tooltip indicator and contrast text
- add inner shadow to track for better visibility
- document indicator behavior in story
- update tests for new tooltip styling

## Testing
- `npx vitest run frontend/src/atoms/Slider/Slider.test.tsx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879054883ec832b8d236ad6d8578e50