### PR TITLE
Improve Switch atom docs and visuals

### DIFF
--- a/frontend/src/atoms/Switch/Switch.docs.mdx
+++ b/frontend/src/atoms/Switch/Switch.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Switch } from './Switch';
+
+<Meta title="Atoms/Switch" of={Switch} />
+
+# Switch
+
+The `Switch` component toggles between on and off states. Use the `intent` prop to control the color when checked.
+
+<Canvas>
+  <Story name="Example">
+    {() => {
+      const [on, setOn] = React.useState(false);
+      return <Switch checked={on} onCheckedChange={setOn} />;
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Switch} />

--- a/frontend/src/atoms/Switch/Switch.stories.tsx
+++ b/frontend/src/atoms/Switch/Switch.stories.tsx
@@ -1,95 +1,82 @@
-import { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
-
 import { Switch, SwitchProps } from './Switch';
 
-export default {
+const meta: Meta<SwitchProps> = {
   title: 'Atoms/Switch',
   component: Switch,
+  tags: ['autodocs'],
   argTypes: {
-    checked: {
-      control: 'boolean',
-      description: 'Whether the switch is checked.',
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    intent: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
     },
-    onCheckedChange: {
-      action: 'checked changed',
-      description: 'Callback when the switch is toggled.',
-    },
-    size: {
-      control: { type: 'radio' },
-      options: ['sm', 'md', 'lg'],
-      description: 'The size of the switch.',
-    },
-    disabled: {
-      control: 'boolean',
-      description: 'Whether the switch is disabled.',
-    },
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    onCheckedChange: { action: 'changed', table: { category: 'Events' } },
   },
-} as Meta;
+};
+export default meta;
 
-const Template: StoryFn<SwitchProps> = (args) => {
-  const [checked, setChecked] = useState(args.checked);
+type Story = StoryObj<typeof meta>;
 
-  React.useEffect(() => {
-    setChecked(args.checked);
-  }, [args.checked]);
-
-  const handleCheckedChange = (isChecked: boolean) => {
-    setChecked(isChecked);
-    args.onCheckedChange(isChecked);
-  };
-
-  return <Switch {...args} checked={checked} onCheckedChange={handleCheckedChange} />;
+export const Default: Story = {
+  render: (args) => {
+    const [val, setVal] = useState(args.checked ?? false);
+    return <Switch {...args} checked={val} onCheckedChange={setVal} />;
+  },
+  args: {
+    checked: false,
+    size: 'md',
+    intent: 'primary',
+  },
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  checked: false,
-  size: 'md',
-  disabled: false,
-};
-
-export const Sizes: StoryFn<SwitchProps> = (args) => (
-  <div className="flex items-center space-x-4">
-    <Switch {...args} size="sm" />
-    <Switch {...args} size="md" />
-    <Switch {...args} size="lg" />
-  </div>
-);
-Sizes.args = {
-  checked: true,
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  checked: false,
-  disabled: true,
-};
-
-export const WithLabel: StoryFn<SwitchProps> = (args) => {
-  const [checked, setChecked] = useState(args.checked);
-
-  const handleCheckedChange = (isChecked: boolean) => {
-    setChecked(isChecked);
-    args.onCheckedChange(isChecked);
-  };
-
-  return (
-    <div className="flex items-center space-x-2">
-      <label htmlFor="night-mode" className="font-medium text-gray-700">
-        Night Mode
-      </label>
-      <Switch
-        {...args}
-        id="night-mode"
-        checked={checked}
-        onCheckedChange={handleCheckedChange}
-      />
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center space-x-4">
+      <Switch {...args} size="sm" />
+      <Switch {...args} size="md" />
+      <Switch {...args} size="lg" />
     </div>
-  );
+  ),
+  args: { checked: true },
 };
-WithLabel.args = {
-  checked: true,
-  size: 'md',
-  disabled: false,
+
+export const Intents: Story = {
+  render: (args) => (
+    <div className="flex items-center space-x-4">
+      <Switch {...args} intent="primary" />
+      <Switch {...args} intent="secondary" />
+      <Switch {...args} intent="tertiary" />
+      <Switch {...args} intent="quaternary" />
+      <Switch {...args} intent="success" />
+    </div>
+  ),
+  args: { checked: true },
+};
+
+export const Disabled: Story = {
+  args: { checked: false, disabled: true },
+};
+
+export const WithLabel: Story = {
+  render: (args) => {
+    const [val, setVal] = useState(args.checked ?? false);
+    return (
+      <div className="flex items-center space-x-2">
+        <label htmlFor="mode" className="font-medium text-gray-700">
+          Night Mode
+        </label>
+        <Switch
+          {...args}
+          id="mode"
+          checked={val}
+          onCheckedChange={setVal}
+        />
+      </div>
+    );
+  },
+  args: { checked: true },
 };

--- a/frontend/src/atoms/Switch/Switch.test.tsx
+++ b/frontend/src/atoms/Switch/Switch.test.tsx
@@ -15,12 +15,14 @@ describe('Switch', () => {
     render(<Switch checked={true} onCheckedChange={() => {}} />);
     const switchElement = screen.getByRole('switch');
     expect(switchElement).toBeChecked();
+    expect(switchElement.className).toContain('bg-primary');
   });
 
   it('should not be checked when the checked prop is false', () => {
     render(<Switch checked={false} onCheckedChange={() => {}} />);
     const switchElement = screen.getByRole('switch');
     expect(switchElement).not.toBeChecked();
+    expect(switchElement.className).toContain('bg-gray-400');
   });
 
   it('should call onCheckedChange when clicked', async () => {
@@ -29,6 +31,12 @@ describe('Switch', () => {
     const switchElement = screen.getByRole('switch');
     await userEvent.click(switchElement);
     expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('applies intent color when checked', () => {
+    render(<Switch checked={true} intent="secondary" onCheckedChange={() => {}} />);
+    const switchElement = screen.getByRole('switch');
+    expect(switchElement.className).toContain('bg-secondary');
   });
 
   it('should toggle state when Space key is pressed', async () => {

--- a/frontend/src/atoms/Switch/Switch.tsx
+++ b/frontend/src/atoms/Switch/Switch.tsx
@@ -52,10 +52,17 @@ export interface SwitchProps
     VariantProps<typeof switchVariants> {
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+  /**
+   * Color used when the switch is checked.
+   */
+  intent?: 'primary' | 'secondary' | 'tertiary' | 'quaternary' | 'success';
 }
 
 const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ className, size, checked, onCheckedChange, ...props }, ref) => {
+  (
+    { className, size, checked, onCheckedChange, intent = 'primary', ...props },
+    ref,
+  ) => {
     return (
       <button
         type="button"
@@ -85,7 +92,16 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
         }}
         className={cn(
           switchVariants({ size }),
-          checked ? 'bg-success-500' : 'bg-gray-200',
+          checked
+            ?
+                {
+                  primary: 'bg-primary',
+                  secondary: 'bg-secondary',
+                  tertiary: 'bg-tertiary',
+                  quaternary: 'bg-quaternary',
+                  success: 'bg-success',
+                }[intent]
+            : 'bg-gray-400',
           'disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}


### PR DESCRIPTION
## Summary
- darken unchecked Switch state
- allow colored checked state via `intent` prop
- document the Switch atom
- streamline Switch stories and tests

## Testing
- `pnpm test -- --run` *(fails: FileUpload, Accordion, Modal)*

------
https://chatgpt.com/codex/tasks/task_e_6879059d93e4832b8b9c00aa7c412327