### PR TITLE
Update heading weights

### DIFF
--- a/frontend/src/atoms/Heading/Heading.docs.mdx
+++ b/frontend/src/atoms/Heading/Heading.docs.mdx
@@ -5,14 +5,17 @@ import { Heading } from './Heading';
 
 # Heading
 
-The `Heading` component renders semantic heading elements with the design system's typography. Use the `level` prop to choose the heading size.
+The `Heading` component renders semantic heading elements with the design system's typography. Use the `level` prop to choose the heading size. Each level also applies a progressively lighter font weight starting at `600` for level 1 down to `100` for level 6.
 
 <Canvas>
   <Story name="Examples">
     <>
-      <Heading level={1}>Heading 1</Heading>
-      <Heading level={2}>Heading 2</Heading>
-      <Heading level={3}>Heading 3</Heading>
+      <Heading level={1}>Heading 1 (600)</Heading>
+      <Heading level={2}>Heading 2 (500)</Heading>
+      <Heading level={3}>Heading 3 (400)</Heading>
+      <Heading level={4}>Heading 4 (300)</Heading>
+      <Heading level={5}>Heading 5 (200)</Heading>
+      <Heading level={6}>Heading 6 (100)</Heading>
     </>
   </Story>
 </Canvas>

--- a/frontend/src/atoms/Heading/Heading.stories.tsx
+++ b/frontend/src/atoms/Heading/Heading.stories.tsx
@@ -27,12 +27,12 @@ export const Default: Story = {
 export const Levels: Story = {
   render: (args) => (
     <div className="space-y-2">
-      <Heading {...args} level={1}>Heading 1</Heading>
-      <Heading {...args} level={2}>Heading 2</Heading>
-      <Heading {...args} level={3}>Heading 3</Heading>
-      <Heading {...args} level={4}>Heading 4</Heading>
-      <Heading {...args} level={5}>Heading 5</Heading>
-      <Heading {...args} level={6}>Heading 6</Heading>
+      <Heading {...args} level={1}>Heading 1 (600)</Heading>
+      <Heading {...args} level={2}>Heading 2 (500)</Heading>
+      <Heading {...args} level={3}>Heading 3 (400)</Heading>
+      <Heading {...args} level={4}>Heading 4 (300)</Heading>
+      <Heading {...args} level={5}>Heading 5 (200)</Heading>
+      <Heading {...args} level={6}>Heading 6 (100)</Heading>
     </div>
   ),
   args: {},

--- a/frontend/src/atoms/Heading/Heading.test.tsx
+++ b/frontend/src/atoms/Heading/Heading.test.tsx
@@ -22,6 +22,27 @@ describe('Heading', () => {
     const heading = screen.getByRole('heading', { level: 4 });
     expect(heading.className).toContain('text-center');
     expect(heading.className).toContain('text-secondary');
+    expect(heading.className).toContain('font-light');
+  });
+
+  it('uses progressively lighter font weights for each level', () => {
+    render(
+      <>
+        <Heading level={1}>One</Heading>
+        <Heading level={2}>Two</Heading>
+        <Heading level={3}>Three</Heading>
+        <Heading level={4}>Four</Heading>
+        <Heading level={5}>Five</Heading>
+        <Heading level={6}>Six</Heading>
+      </>,
+    );
+
+    expect(screen.getByRole('heading', { level: 1 }).className).toContain('font-semibold');
+    expect(screen.getByRole('heading', { level: 2 }).className).toContain('font-medium');
+    expect(screen.getByRole('heading', { level: 3 }).className).toContain('font-normal');
+    expect(screen.getByRole('heading', { level: 4 }).className).toContain('font-light');
+    expect(screen.getByRole('heading', { level: 5 }).className).toContain('font-extralight');
+    expect(screen.getByRole('heading', { level: 6 }).className).toContain('font-thin');
   });
 
   it('merges additional classes', () => {

--- a/frontend/src/atoms/Heading/Heading.tsx
+++ b/frontend/src/atoms/Heading/Heading.tsx
@@ -6,12 +6,12 @@ import { cn } from '@/lib/utils';
 const headingVariants = cva('font-heading', {
   variants: {
     level: {
-      '1': 'text-5xl font-bold tracking-tight',
-      '2': 'text-4xl font-semibold tracking-tight',
-      '3': 'text-3xl font-semibold tracking-tight',
-      '4': 'text-2xl font-semibold tracking-tight',
-      '5': 'text-xl font-semibold tracking-tight',
-      '6': 'text-lg font-semibold tracking-tight',
+      '1': 'text-5xl font-semibold tracking-tight',
+      '2': 'text-4xl font-medium tracking-tight',
+      '3': 'text-3xl font-normal tracking-tight',
+      '4': 'text-2xl font-light tracking-tight',
+      '5': 'text-xl font-extralight tracking-tight',
+      '6': 'text-lg font-thin tracking-tight',
     },
     align: {
       left: 'text-left',


### PR DESCRIPTION
## Summary
- adjust font weights for heading levels 1-6
- update docs and storybook story to showcase the new weight scale
- expand heading tests for weight classes

## Testing
- `pnpm exec vitest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687907986ccc832babea47b1e5d0de81