### PR TITLE
Fix Divider vertical style and tests

### DIFF
--- a/frontend/src/atoms/Divider/Divider.docs.mdx
+++ b/frontend/src/atoms/Divider/Divider.docs.mdx
@@ -15,6 +15,13 @@ Use the `Divider` component to visually separate content. It supports horizontal
       <p>Section 2</p>
     </>
   </Story>
+  <Story name="Vertical example">
+    <div className="flex items-center h-10">
+      <span>Left</span>
+      <Divider orientation="vertical" />
+      <span>Right</span>
+    </div>
+  </Story>
 </Canvas>
 
 <ArgsTable of={Divider} />

--- a/frontend/src/atoms/Divider/Divider.stories.tsx
+++ b/frontend/src/atoms/Divider/Divider.stories.tsx
@@ -31,9 +31,9 @@ export const Horizontal: Story = {
 };
 
 export const Vertical: Story = {
-  args: { orientation: 'vertical', spacing: 'md' },
+  args: { orientation: 'vertical', spacing: 'md', color: 'quaternary' },
   render: (args) => (
-    <div className="flex items-center">
+    <div className="flex items-center h-10">
       <span>Left</span>
       <Divider {...args} />
       <span>Right</span>

--- a/frontend/src/atoms/Divider/Divider.test.tsx
+++ b/frontend/src/atoms/Divider/Divider.test.tsx
@@ -7,6 +7,7 @@ describe('Divider', () => {
     render(<Divider />);
     const separator = screen.getByRole('separator');
     expect(separator.tagName).toBe('HR');
+    expect(separator.className).toContain('border-neutral-400');
   });
 
   it('renders vertical orientation', () => {
@@ -14,6 +15,7 @@ describe('Divider', () => {
     const separator = screen.getByTestId('v');
     expect(separator.tagName).toBe('DIV');
     expect(separator).toHaveAttribute('aria-orientation', 'vertical');
+    expect(separator.className).toContain('w-px');
   });
 
   it('applies spacing variants', () => {
@@ -26,9 +28,12 @@ describe('Divider', () => {
   });
 
   it('applies color variants', () => {
-    render(<Divider color="primary" />);
-    const separator = screen.getByRole('separator');
+    const { rerender } = render(<Divider color="primary" />);
+    let separator = screen.getByRole('separator');
     expect(separator.className).toContain('border-primary');
+    rerender(<Divider color="quaternary" />);
+    separator = screen.getByRole('separator');
+    expect(separator.className).toContain('border-2');
   });
 
   it('accepts custom className', () => {

--- a/frontend/src/atoms/Divider/Divider.tsx
+++ b/frontend/src/atoms/Divider/Divider.tsx
@@ -7,7 +7,7 @@ const dividerVariants = cva('', {
   variants: {
     orientation: {
       horizontal: 'w-full border-t',
-      vertical: 'h-full border-l self-stretch',
+      vertical: 'self-stretch w-px border-l',
     },
     spacing: {
       none: '',
@@ -16,7 +16,7 @@ const dividerVariants = cva('', {
       lg: '',
     },
     color: {
-      default: 'border-border',
+      default: 'border-neutral-400',
       primary: 'border-primary',
       secondary: 'border-secondary',
       tertiary: 'border-tertiary',
@@ -32,6 +32,7 @@ const dividerVariants = cva('', {
     { orientation: 'vertical', spacing: 'sm', className: 'mx-1' },
     { orientation: 'vertical', spacing: 'md', className: 'mx-3' },
     { orientation: 'vertical', spacing: 'lg', className: 'mx-6' },
+    { color: 'quaternary', className: 'border-2' },
   ],
   defaultVariants: {
     orientation: 'horizontal',


### PR DESCRIPTION
## Summary
- improve Divider vertical orientation by ensuring width
- darken default Divider color
- increase quaternary weight
- update docs and storybook for Divider
- update Divider tests

## Testing
- `pnpm --filter erp_system install` *(fails: Cannot use 'in' operator to search for 'errno')*

------
https://chatgpt.com/codex/tasks/task_e_68790832beec832b803f33d5630aa8f0