### PR TITLE
Fix closable Tag

### DIFF
--- a/frontend/src/atoms/Tag/Tag.docs.mdx
+++ b/frontend/src/atoms/Tag/Tag.docs.mdx
@@ -9,11 +9,20 @@ The `Tag` component displays small labels used for categorization or selected fi
 
 <Canvas>
   <Story name="Examples">
-    <>
-      <Tag>Etiqueta</Tag>
-      <Tag variant="solid" color="secondary" className="ml-2">VIP</Tag>
-      <Tag closable className="ml-2">Filtro: Azul</Tag>
-    </>
+    {() => {
+      const [visible, setVisible] = React.useState(true);
+      return (
+        <>
+          <Tag>Etiqueta</Tag>
+          <Tag variant="solid" color="secondary" className="ml-2">VIP</Tag>
+          {visible && (
+            <Tag closable onRemove={() => setVisible(false)} className="ml-2">
+              Filtro: Azul
+            </Tag>
+          )}
+        </>
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/frontend/src/atoms/Tag/Tag.stories.tsx
+++ b/frontend/src/atoms/Tag/Tag.stories.tsx
@@ -30,5 +30,10 @@ export const Solid: Story = {
 };
 
 export const Closable: Story = {
+  render: (args) => {
+    const [visible, setVisible] = React.useState(true);
+    if (!visible) return null;
+    return <Tag {...args} onRemove={() => setVisible(false)} />;
+  },
   args: { closable: true, children: 'Filtro: Azul' },
 };

--- a/frontend/src/atoms/Tag/Tag.test.tsx
+++ b/frontend/src/atoms/Tag/Tag.test.tsx
@@ -34,4 +34,11 @@ describe('Tag', () => {
     expect(onRemove).toHaveBeenCalled();
     expect(button).toHaveAttribute('aria-label', 'Quitar etiqueta');
   });
+
+  it('removes itself when close button is clicked', () => {
+    render(<Tag closable>Filter</Tag>);
+    const tag = screen.getByText('Filter');
+    fireEvent.click(screen.getByRole('button'));
+    expect(tag).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/atoms/Tag/Tag.tsx
+++ b/frontend/src/atoms/Tag/Tag.tsx
@@ -91,16 +91,36 @@ export interface TagProps
 
 export const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
   (
-    { className, variant, color, closable = false, onRemove, removeLabel, children, ...props },
+    {
+      className,
+      variant,
+      color,
+      closable = false,
+      onRemove,
+      removeLabel,
+      children,
+      ...props
+    },
     ref
   ) => {
+    const [visible, setVisible] = React.useState(true);
+
+    if (!visible) {
+      return null;
+    }
+
+    const handleRemove = () => {
+      onRemove?.();
+      setVisible(false);
+    };
+
     return (
       <span ref={ref} className={cn(tagVariants({ variant, color }), className)} {...props}>
         {children}
         {closable && (
           <button
             type="button"
-            onClick={onRemove}
+            onClick={handleRemove}
             aria-label={removeLabel ?? 'Quitar etiqueta'}
             className="ml-1 flex h-4 w-4 items-center justify-center rounded-full hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2"
           >


### PR DESCRIPTION
## Summary
- fix TomoTag closeable behavior so the component hides itself when X is clicked
- add regression test to ensure the component disappears
- update example story with internal state handling
- update docs example

## Testing
- `pnpm test --run src/atoms/Tag/Tag.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687908d68b30832bb33a6c7a3bd5a813