### PR TITLE
Improve tooltip wrap handling

### DIFF
--- a/frontend/src/atoms/Tooltip/Tooltip.docs.mdx
+++ b/frontend/src/atoms/Tooltip/Tooltip.docs.mdx
@@ -14,6 +14,11 @@ The `Tooltip` component displays supplemental information when users hover or fo
       <Button variant="outline">Hover me</Button>
     </Tooltip>
   </Story>
+  <Story name="Long content">
+    <Tooltip content="This tooltip demonstrates how long text wraps onto multiple lines for better readability.">
+      <Button variant="outline">Hover me</Button>
+    </Tooltip>
+  </Story>
 </Canvas>
 
 <ArgsTable of={Tooltip} />

--- a/frontend/src/atoms/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.stories.tsx
@@ -49,3 +49,12 @@ export const Placements: Story = {
   ),
   args: { intent: 'primary' },
 };
+
+export const LongContent: Story = {
+  args: {
+    content:
+      'This tooltip demonstrates how long text will automatically wrap onto multiple lines so that it remains readable.',
+    placement: 'top',
+    intent: 'primary',
+  },
+};

--- a/frontend/src/atoms/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.test.tsx
@@ -39,4 +39,19 @@ describe('Tooltip', () => {
     const arrow = screen.getByRole('tooltip').querySelector('span');
     expect(arrow?.className).toContain('-top-1');
   });
+
+  it('wraps long content', () => {
+    const longText =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut enim ad minim veniam.';
+    render(
+      <Tooltip content={longText}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    const trigger = screen.getByRole('button');
+    fireEvent.mouseEnter(trigger);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.className).toContain('break-words');
+    expect(tooltip.className).toContain('whitespace-pre-line');
+  });
 });

--- a/frontend/src/atoms/Tooltip/Tooltip.tsx
+++ b/frontend/src/atoms/Tooltip/Tooltip.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const tooltipVariants = cva(
-  'pointer-events-none fixed z-50 inline-block rounded-md px-2 py-1 text-xs shadow-md opacity-0 transition-opacity',
+  'pointer-events-none fixed z-50 inline-block rounded-md px-2 py-1 text-xs shadow-md opacity-0 transition-opacity break-words whitespace-pre-line max-w-xs',
   {
     variants: {
       intent: {


### PR DESCRIPTION
## Summary
- ensure Tooltip content wraps by adding `max-w-xs`, `break-words` and `whitespace-pre-line`
- test long content wrapping behavior
- document long content example in Storybook docs
- add LongContent story

## Testing
- `npx vitest run src/atoms/Tooltip`

------
https://chatgpt.com/codex/tasks/task_e_687909830a1c832bae010aecadc936a7