### PR TITLE
Improve warning alert style and behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+pnpm-lock.yaml

--- a/frontend/src/atoms/Alert/Alert.stories.tsx
+++ b/frontend/src/atoms/Alert/Alert.stories.tsx
@@ -59,3 +59,12 @@ export const Dismissable: Story = {
   },
 };
 
+export const AutoDismiss: Story = {
+  args: {
+    variant: 'warning',
+    title: 'Auto ocultable',
+    children: 'Esta alerta desaparece tras 6 segundos o al pasar el mouse.',
+  },
+  parameters: { controls: { disable: true } },
+};
+

--- a/frontend/src/atoms/Alert/Alert.test.tsx
+++ b/frontend/src/atoms/Alert/Alert.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Alert } from './Alert';
 
@@ -14,10 +14,35 @@ describe('Alert', () => {
     expect(alert.className).toContain('border-success');
   });
 
+  it('uses readable text color for warning', () => {
+    render(<Alert variant="warning">warn</Alert>);
+    const alert = screen.getByRole('alert');
+    expect(alert.className).toContain('text-quaternary-foreground');
+  });
+
   it('shows corresponding icon', () => {
     render(<Alert variant="error">fail</Alert>);
     const svg = screen.getByRole('alert').querySelector('svg');
     expect(svg).toBeInTheDocument();
+  });
+
+  it('auto dismisses after 6 seconds', () => {
+    vi.useFakeTimers();
+    render(<Alert>bye</Alert>);
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it('shows close button on hover', () => {
+    render(<Alert>hover me</Alert>);
+    const alert = screen.getByRole('alert');
+    act(() => {
+      fireEvent.mouseEnter(alert);
+    });
+    expect(screen.getByRole('button', { name: /cerrar alerta/i })).toBeInTheDocument();
   });
 
   it('calls onClose when dismissed', () => {

--- a/frontend/src/atoms/Alert/Alert.tsx
+++ b/frontend/src/atoms/Alert/Alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
       variant: {
         info: 'bg-secondary/20 text-secondary border-secondary',
         success: 'bg-success/20 text-success border-success',
-        warning: 'bg-quaternary/20 text-quaternary border-quaternary',
+        warning: 'bg-quaternary/20 text-quaternary-foreground border-quaternary',
         error: 'bg-destructive/20 text-destructive border-destructive',
       },
     },
@@ -43,6 +43,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     ref,
   ) => {
     const [visible, setVisible] = React.useState(true);
+    const [hovered, setHovered] = React.useState(false);
     const Icon = iconMap[variant ?? 'info'];
 
     const handleClose = () => {
@@ -50,26 +51,41 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       setVisible(false);
     };
 
+    React.useEffect(() => {
+      const timer = setTimeout(handleClose, 6000);
+      return () => clearTimeout(timer);
+    }, []);
+
     if (!visible) return null;
 
     return (
       <div
         role="alert"
         ref={ref}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
         className={cn(alertVariants({ variant, className }))}
         {...props}
       >
-        <Icon className="mt-0.5 flex-shrink-0" size={20} aria-hidden="true" />
+        <Icon
+          className={cn(
+            'mt-0.5 flex-shrink-0',
+            variant === 'warning' && 'text-quaternary'
+          )}
+          size={20}
+          aria-hidden="true"
+        />
         <div className="flex-1">
           {title && <h5 className="font-semibold mb-1">{title}</h5>}
           {children}
         </div>
-        {dismissable && (
+        {(dismissable || hovered) && (
           <button
             type="button"
             onClick={handleClose}
             aria-label="Cerrar alerta"
-            className="absolute top-2 right-2 rounded p-1 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+            className="absolute top-2 right-2 rounded p-1 opacity-0 transition-opacity hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+            style={{ opacity: dismissable || hovered ? 1 : 0 }}
           >
             <X size={14} />
           </button>


### PR DESCRIPTION
## Summary
- tweak warning alert color for better contrast
- auto-dismiss alerts after 6s
- show close icon on hover
- add AutoDismiss story
- expand Alert tests
- ignore node_modules

## Testing
- `CI=1 pnpm test src/atoms/Alert/Alert.test.tsx --run`
- `CI=1 pnpm test --run` *(fails: FileUpload, Accordion, Modal tests)*

------
https://chatgpt.com/codex/tasks/task_e_687909fa5718832b8d444f622eb64985