### PR TITLE
Update Spinner atom colors and animation

### DIFF
--- a/frontend/src/atoms/Spinner/Spinner.docs.mdx
+++ b/frontend/src/atoms/Spinner/Spinner.docs.mdx
@@ -11,8 +11,11 @@ The `Spinner` component displays a rotating indicator to signal that content is 
   <Story name="Examples">
     <div className="flex items-center space-x-4">
       <Spinner />
-      <Spinner size="sm" />
-      <Spinner size="lg" intent="secondary" />
+      <Spinner size="sm" intent="secondary" />
+      <Spinner size="md" intent="tertiary" />
+      <Spinner size="md" intent="quaternary" />
+      <Spinner size="md" intent="success" />
+      <Spinner size="lg" intent="destructive" />
     </div>
   </Story>
 </Canvas>

--- a/frontend/src/atoms/Spinner/Spinner.stories.tsx
+++ b/frontend/src/atoms/Spinner/Spinner.stories.tsx
@@ -7,7 +7,17 @@ const meta: Meta<SpinnerProps> = {
   tags: ['autodocs'],
   argTypes: {
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
-    intent: { control: 'select', options: ['primary', 'secondary'] },
+    intent: {
+      control: 'select',
+      options: [
+        'primary',
+        'secondary',
+        'tertiary',
+        'quaternary',
+        'success',
+        'destructive',
+      ],
+    },
     label: { control: 'text' },
   },
 };
@@ -19,3 +29,15 @@ export const Default: Story = {};
 export const Small: Story = { args: { size: 'sm' } };
 export const Large: Story = { args: { size: 'lg' } };
 export const Secondary: Story = { args: { intent: 'secondary' } };
+export const AllColors: Story = {
+  render: (args) => (
+    <div className="flex items-center space-x-4">
+      <Spinner {...args} intent="primary" />
+      <Spinner {...args} intent="secondary" />
+      <Spinner {...args} intent="tertiary" />
+      <Spinner {...args} intent="quaternary" />
+      <Spinner {...args} intent="success" />
+      <Spinner {...args} intent="destructive" />
+    </div>
+  ),
+};

--- a/frontend/src/atoms/Spinner/Spinner.test.tsx
+++ b/frontend/src/atoms/Spinner/Spinner.test.tsx
@@ -6,7 +6,8 @@ describe('Spinner', () => {
   it('renders with default classes', () => {
     render(<Spinner />);
     const spinner = screen.getByRole('status');
-    expect(spinner).toHaveClass('animate-spin');
+    expect(spinner).toHaveClass('animate-spinner-fancy');
+    expect(spinner).toHaveClass('border-primary');
   });
 
   it('applies size variants', () => {
@@ -17,6 +18,16 @@ describe('Spinner', () => {
     rerender(<Spinner size="lg" />);
     spinner = screen.getByRole('status');
     expect(spinner).toHaveClass('h-8 w-8');
+  });
+
+  it('applies color variants', () => {
+    const { rerender } = render(<Spinner intent="secondary" />);
+    let spinner = screen.getByRole('status');
+    expect(spinner).toHaveClass('border-secondary');
+
+    rerender(<Spinner intent="success" />);
+    spinner = screen.getByRole('status');
+    expect(spinner).toHaveClass('border-success');
   });
 
   it('renders accessible label', () => {

--- a/frontend/src/atoms/Spinner/Spinner.tsx
+++ b/frontend/src/atoms/Spinner/Spinner.tsx
@@ -2,23 +2,32 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-const spinnerVariants = cva('animate-spin rounded-full border-4 border-solid', {
-  variants: {
-    intent: {
-      primary: 'border-b-transparent border-l-transparent',
-      secondary: 'border-b-transparent border-l-transparent',
+const spinnerVariants = cva(
+  'animate-spinner-fancy rounded-full border-4 border-solid',
+  {
+    variants: {
+      intent: {
+        primary: 'border-primary border-b-transparent border-l-transparent',
+        secondary: 'border-secondary border-b-transparent border-l-transparent',
+        tertiary: 'border-tertiary border-b-transparent border-l-transparent',
+        quaternary:
+          'border-quaternary border-b-transparent border-l-transparent',
+        success: 'border-success border-b-transparent border-l-transparent',
+        destructive:
+          'border-destructive border-b-transparent border-l-transparent',
+      },
+      size: {
+        sm: 'h-4 w-4',
+        md: 'h-6 w-6',
+        lg: 'h-8 w-8',
+      },
     },
-    size: {
-      sm: 'h-4 w-4',
-      md: 'h-6 w-6',
-      lg: 'h-8 w-8',
+    defaultVariants: {
+      intent: 'primary',
+      size: 'md',
     },
   },
-  defaultVariants: {
-    intent: 'primary',
-    size: 'md',
-  },
-});
+);
 
 export interface SpinnerProps
   extends React.HTMLAttributes<HTMLDivElement>,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -197,3 +197,12 @@
     width: 50%;
     animation: progress-indeterminate 1s infinite linear;
   }
+
+  @keyframes spinner-fancy {
+    0% { transform: rotate(0deg); opacity: 1; }
+    50% { opacity: 0.6; }
+    100% { transform: rotate(360deg); opacity: 1; }
+  }
+  .animate-spinner-fancy {
+    animation: spinner-fancy 0.8s linear infinite;
+  }


### PR DESCRIPTION
## Summary
- enhance Spinner atom to allow all intent colors
- add a smoother animation
- document new color options
- showcase color variants in Storybook
- extend Spinner tests for colors and animation

## Testing
- `node ../node_modules/.pnpm/vitest@1.6.1_@types+node@24.0.14_jsdom@26.1.0/node_modules/vitest/vitest.mjs run src/atoms/Spinner/Spinner.test.tsx --config vite.config.ts --silent`

------
https://chatgpt.com/codex/tasks/task_e_68790a26aee4832b9af99523213f0be3