### PR TITLE
Fix Storybook alias

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,9 +1,25 @@
 /** @type { import('@storybook/react-vite').StorybookConfig } */
+import { mergeConfig } from 'vite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const config = {
   framework: "@storybook/react-vite",
   stories: ["../src/**/*.stories.@(js|jsx|ts|tsx|mdx)"],
   addons: ["@storybook/addon-essentials"],
   core: { disableTelemetry: true },
+  async viteFinal(config) {
+    return mergeConfig(config, {
+      resolve: {
+        alias: {
+          '@': path.resolve(__dirname, '../src'),
+        },
+      },
+    });
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- configure Storybook with Vite alias for `@`

## Testing
- `pnpm --filter ./frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790a94f8dc832bbb3d4d84c50da00d