### PR TITLE
Enhance progress bar display

### DIFF
--- a/frontend/src/atoms/ProgressBar/ProgressBar.docs.mdx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.docs.mdx
@@ -5,7 +5,7 @@ import { ProgressBar } from './ProgressBar';
 
 # ProgressBar
 
-Displays the progress of a task. Provide a `value` between 0 and 100 for determinate mode or omit the prop for an indeterminate bar.
+Displays the progress of a task. Provide a `value` between 0 and 100 for determinate mode or omit the prop for an indeterminate bar. When a value is supplied the percentage is shown inside the bar.
 
 <Canvas>
   <Story name="Examples">

--- a/frontend/src/atoms/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.test.tsx
@@ -5,14 +5,18 @@ import { ProgressBar } from './ProgressBar';
 describe('ProgressBar', () => {
   it('applies width based on value', () => {
     render(<ProgressBar value={40} />);
-    const indicator = screen.getByRole('progressbar').firstChild as HTMLElement;
+    const bar = screen.getByRole('progressbar');
+    const indicator = bar.firstChild as HTMLElement;
     expect(indicator).toHaveStyle('width: 40%');
+    expect(screen.getByText('40%')).toBeInTheDocument();
   });
 
   it('renders indeterminate animation when no value', () => {
     render(<ProgressBar />);
-    const indicator = screen.getByRole('progressbar').firstChild as HTMLElement;
+    const bar = screen.getByRole('progressbar');
+    const indicator = bar.firstChild as HTMLElement;
     expect(indicator.className).toContain('animate-indeterminate');
+    expect(bar.textContent).toBe('');
   });
 
   it('applies size variants', () => {
@@ -22,5 +26,10 @@ describe('ProgressBar', () => {
 
     rerender(<ProgressBar size="lg" value={10} />);
     expect(bar).toHaveClass('h-3');
+  });
+
+  it('shows clamped value text', () => {
+    render(<ProgressBar value={150} />);
+    expect(screen.getByText('100%')).toBeInTheDocument();
   });
 });

--- a/frontend/src/atoms/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
-const trackVariants = cva('w-full bg-muted rounded-full overflow-hidden relative', {
-  variants: {
+const trackVariants = cva(
+  'w-full bg-border rounded-full overflow-hidden relative',
+  {
+    variants: {
     size: {
       sm: 'h-1.5',
       md: 'h-2',
@@ -54,9 +56,22 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
         {...props}
       >
         {isIndeterminate ? (
-          <div className={cn(indicatorVariants({ color }), 'animate-indeterminate')} />
+          <div
+            className={cn(
+              indicatorVariants({ color }),
+              'animate-indeterminate',
+            )}
+          />
         ) : (
-          <div className={indicatorVariants({ color })} style={{ width: `${clamped}%` }} />
+          <>
+            <div
+              className={indicatorVariants({ color })}
+              style={{ width: `${clamped}%` }}
+            />
+            <span className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground font-medium">
+              {clamped}%
+            </span>
+          </>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary
- darken progress bar track for better contrast
- display numeric progress value when determinate
- document new behavior in storybook docs
- test numeric indicator and clamping

## Testing
- `pnpm test --run src/atoms/ProgressBar/ProgressBar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68790b445b58832b8c42b358a0b6b6df