### PR TITLE
Improve table atom

### DIFF
--- a/frontend/src/atoms/Table/Table.docs.mdx
+++ b/frontend/src/atoms/Table/Table.docs.mdx
@@ -5,31 +5,19 @@ import { Table } from './Table';
 
 # Table
 
-The `Table` component applies consistent styles to HTML tables. Use the `variant`, `size`, and `color` props to control the appearance.
+The `Table` component applies consistent styles to HTML tables. Use `variant`, `size`, and `color` props to control the appearance. It can also render data automatically via the `columns` and `data` props, support sortable headers, highlight rows on hover and become responsive with horizontal scrolling.
 
 <Canvas>
   <Story name="Example">
-    <Table caption="Sample data">
-      <thead>
-        <tr>
-          <th>Producto</th>
-          <th>Stock</th>
-          <th>Precio</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Camiseta</td>
-          <td>25</td>
-          <td>$12</td>
-        </tr>
-        <tr>
-          <td>Pantalón</td>
-          <td>10</td>
-          <td>$25</td>
-        </tr>
-      </tbody>
-    </Table>
+    <Table caption="Sample data" columns={[
+      { key: 'producto', header: 'Producto', sortable: true },
+      { key: 'stock', header: 'Stock', sortable: true },
+      { key: 'precio', header: 'Precio', sortable: true }
+    ]} data={[
+      { producto: 'Camiseta', stock: 25, precio: 12 },
+      { producto: 'Pantalón', stock: 10, precio: 25 },
+      { producto: 'Zapatos', stock: 5, precio: 50 }
+    ]} hoverable />
   </Story>
 </Canvas>
 

--- a/frontend/src/atoms/Table/Table.stories.tsx
+++ b/frontend/src/atoms/Table/Table.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Table, TableProps } from './Table';
+import { Table, TableProps, Column } from './Table';
 
 const meta: Meta<TableProps> = {
   title: 'Atoms/Table',
@@ -13,6 +13,8 @@ const meta: Meta<TableProps> = {
       options: ['muted', 'primary', 'secondary', 'tertiary', 'quaternary', 'success'],
     },
     caption: { control: 'text' },
+    hoverable: { control: 'boolean' },
+    responsive: { control: 'boolean' },
   },
 };
 
@@ -20,57 +22,63 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const columns: Column[] = [
+  { key: 'producto', header: 'Producto', sortable: true },
+  { key: 'stock', header: 'Stock', sortable: true },
+  { key: 'precio', header: 'Precio', sortable: true },
+];
+
+const data = [
+  { producto: 'Camiseta', stock: 25, precio: 12 },
+  { producto: 'Pantalón', stock: 10, precio: 25 },
+  { producto: 'Zapatos', stock: 5, precio: 50 },
+];
+
 export const Default: Story = {
   args: {
     caption: 'Example inventory table',
-    children: (
-      <>
-        <thead>
-          <tr>
-            <th>Producto</th>
-            <th>Stock</th>
-            <th>Precio</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Camiseta</td>
-            <td>25</td>
-            <td>$12</td>
-          </tr>
-          <tr>
-            <td>Pantalón</td>
-            <td>10</td>
-            <td>$25</td>
-          </tr>
-        </tbody>
-      </>
-    ),
+    columns,
+    data,
+    hoverable: true,
   },
 };
 
 export const Striped: Story = {
   args: {
     variant: 'striped',
-    children: (
-      <>
-        <thead>
-          <tr>
-            <th>Cliente</th>
-            <th>Correo</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Ana</td>
-            <td>ana@example.com</td>
-          </tr>
-          <tr>
-            <td>Juan</td>
-            <td>juan@example.com</td>
-          </tr>
-        </tbody>
-      </>
-    ),
+    columns: [
+      { key: 'cliente', header: 'Cliente' },
+      { key: 'correo', header: 'Correo' },
+    ],
+    data: [
+      { cliente: 'Ana', correo: 'ana@example.com' },
+      { cliente: 'Juan', correo: 'juan@example.com' },
+    ],
+    hoverable: true,
+  },
+};
+
+export const Sortable: Story = {
+  args: {
+    columns,
+    data,
+    hoverable: true,
+  },
+};
+
+export const Responsive: Story = {
+  args: {
+    responsive: true,
+    columns: [
+      { key: 'a', header: 'Column A' },
+      { key: 'b', header: 'Column B' },
+      { key: 'c', header: 'Column C' },
+      { key: 'd', header: 'Column D' },
+      { key: 'e', header: 'Column E' },
+    ],
+    data: [
+      { a: 1, b: 2, c: 3, d: 4, e: 5 },
+      { a: 6, b: 7, c: 8, d: 9, e: 10 },
+    ],
   },
 };

--- a/frontend/src/atoms/Table/Table.test.tsx
+++ b/frontend/src/atoms/Table/Table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Table } from './Table';
 
@@ -42,5 +42,44 @@ describe('Table', () => {
       </Table>
     );
     expect(screen.getByText('info')).toBeInTheDocument();
+  });
+
+  it('renders rows from data prop', () => {
+    render(
+      <Table columns={[{ key: 'name', header: 'Name' }]} data={[{ name: 'Ana' }]} />,
+    );
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+  });
+
+  it('sorts data when header is clicked', () => {
+    const columns = [
+      { key: 'name', header: 'Name', sortable: true },
+      { key: 'age', header: 'Age', sortable: true },
+    ];
+    const data = [
+      { name: 'John', age: 30 },
+      { name: 'Alice', age: 20 },
+    ];
+
+    render(<Table columns={columns} data={data} />);
+
+    const ageHeader = screen.getByText('Age');
+    fireEvent.click(ageHeader);
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('Alice');
+    fireEvent.click(ageHeader);
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('John');
+  });
+
+  it('applies hover class when hoverable', () => {
+    render(
+      <Table hoverable>
+        <tbody>
+          <tr><td>1</td></tr>
+        </tbody>
+      </Table>,
+    );
+    const table = screen.getByRole('table');
+    expect(table.className).toContain('tbody_tr:hover');
   });
 });

--- a/frontend/src/atoms/Table/Table.tsx
+++ b/frontend/src/atoms/Table/Table.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
+import {
+  ChevronDown,
+  ChevronUp,
+  ChevronsUpDown,
+} from 'lucide-react';
 
 const tableVariants = cva(
   'w-full caption-bottom text-sm text-left border-collapse text-foreground [&_th]:border-b [&_th]:text-left [&_th]:font-semibold [&_th]:px-3 [&_td]:px-3 [&_td]:py-2 [&_th]:py-2 [&_td]:border-b [&_tr:last-child_>_td]:border-0',
@@ -23,6 +28,9 @@ const tableVariants = cva(
         quaternary: '[&_th]:bg-quaternary [&_th]:text-quaternary-foreground',
         success: '[&_th]:bg-success [&_th]:text-success-foreground',
       },
+      hoverable: {
+        true: '[&_tbody_tr:hover]:bg-muted',
+      },
     },
     defaultVariants: {
       variant: 'simple',
@@ -32,20 +40,140 @@ const tableVariants = cva(
   },
 );
 
+export interface Column {
+  /** Key in the data object */
+  key: string;
+  /** Header label */
+  header: React.ReactNode;
+  /** Whether the column can be sorted */
+  sortable?: boolean;
+  /** Custom cell renderer */
+  render?: (row: Record<string, any>) => React.ReactNode;
+}
+
 export interface TableProps
   extends React.HTMLAttributes<HTMLTableElement>,
     VariantProps<typeof tableVariants> {
   /** Caption for the table, placed below */
   caption?: string;
+  /** Column definitions for data driven tables */
+  columns?: Column[];
+  /** Data records for data driven tables */
+  data?: Record<string, any>[];
+  /** Highlight rows on hover */
+  hoverable?: boolean;
+  /** Wrap table in a responsive container */
+  responsive?: boolean;
 }
 
 export const Table = React.forwardRef<HTMLTableElement, TableProps>(
-  ({ className, variant, size, color, caption, children, ...props }, ref) => (
-    <table ref={ref} className={cn(tableVariants({ variant, size, color }), className)} {...props}>
-      {children}
-      {caption && <caption className="mt-2 text-sm text-muted-foreground">{caption}</caption>}
-    </table>
-  ),
+  (
+    {
+      className,
+      variant,
+      size,
+      color,
+      caption,
+      columns,
+      data,
+      hoverable,
+      responsive,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const [sortConfig, setSortConfig] = React.useState<{
+      key: string;
+      direction: 'asc' | 'desc';
+    }>();
+
+    const handleSort = (key: string) => {
+      setSortConfig((prev) => {
+        if (!prev || prev.key !== key) return { key, direction: 'asc' };
+        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      });
+    };
+
+    const sortedData = React.useMemo(() => {
+      if (!data) return undefined;
+      if (!sortConfig) return data;
+      return [...data].sort((a, b) => {
+        const aVal = a[sortConfig.key];
+        const bVal = b[sortConfig.key];
+        if (aVal === undefined || bVal === undefined) return 0;
+        if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1;
+        if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1;
+        return 0;
+      });
+    }, [data, sortConfig]);
+
+    const table = (
+      <table
+        ref={ref}
+        className={cn(
+          tableVariants({ variant, size, color, hoverable }),
+          className,
+        )}
+        {...props}
+      >
+        {columns && sortedData ? (
+          <>
+            <thead>
+              <tr>
+                {columns.map((col) => (
+                  <th
+                    key={col.key}
+                    onClick={col.sortable ? () => handleSort(col.key) : undefined}
+                    className={cn(col.sortable && 'cursor-pointer select-none')}
+                  >
+                    <span className="flex items-center">
+                      {col.header}
+                      {col.sortable && (
+                        sortConfig?.key === col.key ? (
+                          sortConfig.direction === 'asc' ? (
+                            <ChevronUp className="ml-1 h-3 w-3" />
+                          ) : (
+                            <ChevronDown className="ml-1 h-3 w-3" />
+                          )
+                        ) : (
+                          <ChevronsUpDown className="ml-1 h-3 w-3 opacity-50" />
+                        )
+                      )}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sortedData.map((row, rowIndex) => (
+                <tr key={rowIndex}>
+                  {columns.map((col) => (
+                    <td key={col.key}>
+                      {col.render ? col.render(row) : (row as any)[col.key]}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </>
+        ) : (
+          children
+        )}
+        {caption && (
+          <caption className="mt-2 text-sm text-muted-foreground">
+            {caption}
+          </caption>
+        )}
+      </table>
+    );
+
+    return responsive ? (
+      <div className="w-full overflow-x-auto">{table}</div>
+    ) : (
+      table
+    );
+  },
 );
 Table.displayName = 'Table';
 


### PR DESCRIPTION
## Summary
- enhance Table atom with sorting, hover highlighting and responsive container
- add storybook stories for sortable and responsive cases
- update docs with new props
- extend unit tests for new features

## Testing
- `pnpm test` *(fails: FileUpload, Accordion, Modal tests)*

------
https://chatgpt.com/codex/tasks/task_e_68790bb8cc68832b96d587a508e4ec12