### PR TITLE
Improve Toast atom with icon

### DIFF
--- a/frontend/src/atoms/Toast/Toast.docs.mdx
+++ b/frontend/src/atoms/Toast/Toast.docs.mdx
@@ -6,14 +6,23 @@ import { Toast } from './Toast';
 # Toast
 
 The `Toast` component displays brief non-intrusive messages. Use it to confirm actions or show information that doesn't require a full alert.
+By default an icon indicating the intent is shown. Use `showIcon={false}` to hide it. A close button is also available if `onDismiss` is provided.
 
 <Canvas>
-  <Story name="Examples">
-    <>
-      <Toast>Info message</Toast>
-      <Toast intent="success" className="mt-4">Success message</Toast>
-      <Toast intent="error" className="mt-4">Error message</Toast>
-    </>
+  <Story name="Info">
+    <Toast>Info message</Toast>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Success">
+    <Toast intent="success">Success message</Toast>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Error">
+    <Toast intent="error">Error message</Toast>
   </Story>
 </Canvas>
 

--- a/frontend/src/atoms/Toast/Toast.stories.tsx
+++ b/frontend/src/atoms/Toast/Toast.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<ToastProps> = {
     },
     duration: { control: 'number' },
     showClose: { control: 'boolean' },
+    showIcon: { control: 'boolean' },
   },
 };
 

--- a/frontend/src/atoms/Toast/Toast.test.tsx
+++ b/frontend/src/atoms/Toast/Toast.test.tsx
@@ -10,6 +10,22 @@ describe('Toast', () => {
     expect(toast.className).toContain('bg-success');
   });
 
+  it('shows intent icon by default', () => {
+    render(<Toast intent="error">Error!</Toast>);
+    const icon = screen.getByRole('status').querySelector('svg');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('hides icon when showIcon is false', () => {
+    render(
+      <Toast intent="info" showIcon={false}>
+        Hidden icon
+      </Toast>,
+    );
+    const icon = screen.getByRole('status').querySelector('svg');
+    expect(icon).toBeNull();
+  });
+
   it('calls onDismiss after duration', () => {
     vi.useFakeTimers();
     const onDismiss = vi.fn();

--- a/frontend/src/atoms/Toast/Toast.tsx
+++ b/frontend/src/atoms/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { X } from 'lucide-react';
+import { X, Info, CheckCircle2, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const toastVariants = cva(
@@ -32,35 +32,63 @@ export interface ToastProps
   duration?: number;
   onDismiss?: () => void;
   showClose?: boolean;
+  showIcon?: boolean;
 }
 
-export const Toast: React.FC<ToastProps> = ({
-  className,
-  intent,
-  position,
-  duration = 3000,
-  onDismiss,
-  showClose = true,
-  children,
-  ...props
-}) => {
-  React.useEffect(() => {
-    if (!onDismiss) return;
-    const timer = setTimeout(() => onDismiss(), duration);
-    return () => clearTimeout(timer);
-  }, [onDismiss, duration]);
+type ToastIntent = VariantProps<typeof toastVariants>['intent'];
 
-  return (
-    <div className={cn(toastVariants({ intent, position }), className)} role="status" {...props}>
-      <div className="flex-1">{children}</div>
-      {showClose && onDismiss && (
-        <button onClick={onDismiss} aria-label="Close" className="ml-2">
-          <X size={16} />
-        </button>
-      )}
-    </div>
-  );
+const iconMap: Record<ToastIntent, React.ElementType> = {
+  info: Info,
+  success: CheckCircle2,
+  error: AlertCircle,
 };
+
+export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
+  (
+    {
+      className,
+      intent,
+      position,
+      duration = 3000,
+      onDismiss,
+      showClose = true,
+      showIcon = true,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    React.useEffect(() => {
+      if (!onDismiss) return;
+      const timer = setTimeout(() => onDismiss(), duration);
+      return () => clearTimeout(timer);
+    }, [onDismiss, duration]);
+
+    const Icon = iconMap[intent ?? 'info'];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(toastVariants({ intent, position }), className)}
+        role="status"
+        {...props}
+      >
+        {showIcon && <Icon size={16} aria-hidden="true" />}
+        <div className="flex-1">{children}</div>
+        {showClose && onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Close"
+            className="ml-2"
+          >
+            <X size={16} />
+          </button>
+        )}
+      </div>
+    );
+  },
+);
 
 Toast.displayName = 'Toast';
 


### PR DESCRIPTION
## Summary
- add intent icons and forwardRef to Toast
- update Toast tests and stories for the icon
- clarify usage in docs

## Testing
- `node_modules/.pnpm/node_modules/.bin/vitest run` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68790ca75910832b88b9c7a593d0ff07