### PR TITLE
Fix modal close action

### DIFF
--- a/frontend/src/atoms/Modal/Modal.test.tsx
+++ b/frontend/src/atoms/Modal/Modal.test.tsx
@@ -45,6 +45,13 @@ describe('Modal', () => {
     expect(screen.getByLabelText(/close/i)).toBeInTheDocument();
   });
 
+  it('calls onClose when close button clicked', () => {
+    const onClose = vi.fn();
+    renderModal(true, onClose);
+    fireEvent.click(screen.getByLabelText(/close/i));
+    expect(onClose).toHaveBeenCalled();
+  });
+
   it('applies variant classes', () => {
     renderModal(true, vi.fn(), { variant: 'primary' });
     expect(screen.getByRole('dialog').className).toContain('bg-primary');

--- a/frontend/src/atoms/Modal/Modal.tsx
+++ b/frontend/src/atoms/Modal/Modal.tsx
@@ -99,7 +99,10 @@ export const Modal: React.FC<ModalProps> = ({
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
         aria-hidden="true"
-        onClick={onClose}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
       />
       <div
         role="dialog"
@@ -117,7 +120,10 @@ export const Modal: React.FC<ModalProps> = ({
         <button
           type="button"
           aria-label="Close"
-          onClick={onClose}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
           className="absolute top-2 right-2 rounded-md p-1 text-muted hover:bg-muted hover:text-foreground focus:outline-none"
         >
           <X size={18} />


### PR DESCRIPTION
## Summary
- prevent event bubbling when overlay or close button is clicked
- add test to verify close button triggers `onClose`

## Testing
- `pnpm --filter ./frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879184eec4c832b84c2c217b7492e6f