### PR TITLE
Fix accordion toggle in Tabs atom

### DIFF
--- a/frontend/src/atoms/Button/Button.test.tsx
+++ b/frontend/src/atoms/Button/Button.test.tsx
@@ -50,7 +50,7 @@ describe('Button', () => {
     expect(button).toBeDisabled();
 
     // Spinner should be present with an accessible label
-    const spinner = button.querySelector('.animate-spin');
+    const spinner = button.querySelector('.animate-spinner-fancy');
     expect(spinner).toBeInTheDocument();
     expect(screen.getByText('Loading...')).toHaveClass('sr-only');
   });

--- a/frontend/src/atoms/Tabs/Tabs.test.tsx
+++ b/frontend/src/atoms/Tabs/Tabs.test.tsx
@@ -43,4 +43,12 @@ describe('Tabs', () => {
     fireEvent.click(screen.getByText('Two'));
     expect(screen.getByText('Second')).toBeVisible();
   });
+
+  it('toggles accordion item when clicking the active header', () => {
+    render(<Tabs items={items} variant="accordion" />);
+    const firstHeader = screen.getByText('One');
+    // first item is open by default
+    fireEvent.click(firstHeader);
+    expect(screen.queryByText('First')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/atoms/Tabs/Tabs.tsx
+++ b/frontend/src/atoms/Tabs/Tabs.tsx
@@ -100,7 +100,7 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
                     colorClasses[color].accordion,
                     !isActive && 'text-muted-foreground',
                   )}
-                  onClick={() => setActive(index)}
+                  onClick={() => setActive((prev) => (prev === index ? -1 : index))}
                 >
                   <span>{item.label}</span>
                   <ChevronDown
@@ -108,14 +108,16 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
                     className={cn('transition-transform', isActive && 'rotate-180')}
                   />
                 </button>
-                <div
-                  id={panelId}
-                  role="tabpanel"
-                  aria-labelledby={id}
-                  className={cn('pt-1 pb-2 text-sm', !isActive && 'hidden')}
-                >
-                  {item.content}
-                </div>
+                {isActive && (
+                  <div
+                    id={panelId}
+                    role="tabpanel"
+                    aria-labelledby={id}
+                    className="pt-1 pb-2 text-sm"
+                  >
+                    {item.content}
+                  </div>
+                )}
               </div>
             );
           })}


### PR DESCRIPTION
## Summary
- allow collapsing accordion tab on second click
- only render accordion panel when active
- update tests for accordion toggle
- fix spinner class check in Button tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687918fef6f4832babe46b4aab9c50b7