### PR TITLE
Fix overlapping placeholder and label

### DIFF
--- a/frontend/src/atoms/Input/Input.tsx
+++ b/frontend/src/atoms/Input/Input.tsx
@@ -121,7 +121,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type="text"
           ref={ref}
           aria-invalid={error ? "true" : undefined}
-          placeholder={label ? " " : props.placeholder}
           className={cn(
             inputVariants({
               size,
@@ -135,6 +134,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           )}
           onChange={handleChange}
           {...props}
+          placeholder={label ? " " : props.placeholder}
         />
         {label && (
           <label

--- a/frontend/src/atoms/Textarea/Textarea.tsx
+++ b/frontend/src/atoms/Textarea/Textarea.tsx
@@ -123,20 +123,20 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const appliedRows = rows ?? (autoResize ? 1 : sizeRows[size ?? "md"]);
 
     return (
-      <div className="relative">
-        <textarea
-          id={textareaId}
-          ref={setRefs}
-          rows={appliedRows}
-          aria-invalid={error ? "true" : undefined}
-          placeholder={label ? " " : props.placeholder}
-          className={cn(
-            textareaVariants({ size, variant, color, error, className }),
-            autoResize ? "resize-none overflow-hidden transition-all" : "resize-y",
-          )}
-          onChange={handleChange}
-          {...props}
-        />
+        <div className="relative">
+          <textarea
+            id={textareaId}
+            ref={setRefs}
+            rows={appliedRows}
+            aria-invalid={error ? "true" : undefined}
+            className={cn(
+              textareaVariants({ size, variant, color, error, className }),
+              autoResize ? "resize-none overflow-hidden transition-all" : "resize-y",
+            )}
+            onChange={handleChange}
+            {...props}
+            placeholder={label ? " " : props.placeholder}
+          />
         {label && (
           <label
             htmlFor={textareaId}


### PR DESCRIPTION
## Summary
- ensure the placeholder prop is overwritten when label is provided for `Input`
- apply the same fix to `Textarea`

## Testing
- `pnpm --dir frontend exec vitest run` *(fails: Button spinner test)*

------
https://chatgpt.com/codex/tasks/task_e_68791752deb8832bbba9783e0e0788d7