### PR TITLE
Add NavItem molecule

### DIFF
--- a/frontend/src/molecules/NavItem/NavItem.docs.mdx
+++ b/frontend/src/molecules/NavItem/NavItem.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { NavItem } from './NavItem';
+
+<Meta title="Molecules/NavItem" of={NavItem} />
+
+# NavItem
+
+The `NavItem` component represents a menu item used in navigation bars or sidebars. It shows an icon, a label and optionally a notification badge.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="w-48 space-y-2">
+      <NavItem iconName="Home" label="Inicio" active />
+      <NavItem iconName="Folder" label="Proyectos" />
+      <NavItem iconName="Mail" label="Mensajes" showBadge badgeCount={5} />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={NavItem} />

--- a/frontend/src/molecules/NavItem/NavItem.stories.tsx
+++ b/frontend/src/molecules/NavItem/NavItem.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NavItem, NavItemProps } from './NavItem';
+import { iconMap, type IconName } from '@/atoms/Icon';
+
+interface NavItemStoryProps extends NavItemProps {
+  iconName: IconName;
+}
+
+const iconOptions = Object.keys(iconMap) as IconName[];
+
+const meta: Meta<NavItemStoryProps> = {
+  title: 'Molecules/NavItem',
+  component: NavItem,
+  tags: ['autodocs'],
+  argTypes: {
+    iconName: { control: 'select', options: iconOptions },
+    label: { control: 'text' },
+    active: { control: 'boolean' },
+    showBadge: { control: 'boolean' },
+    badgeCount: { control: 'number' },
+    onClick: { action: 'clicked' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    iconName: 'Home',
+    label: 'Inicio',
+    active: false,
+    showBadge: false,
+    badgeCount: 0,
+  },
+};
+
+export const Active: Story = {
+  args: {
+    iconName: 'Home',
+    label: 'Inicio',
+    active: true,
+  },
+};
+
+export const WithBadge: Story = {
+  args: {
+    iconName: 'Mail',
+    label: 'Mensajes',
+    showBadge: true,
+    badgeCount: 3,
+  },
+};

--- a/frontend/src/molecules/NavItem/NavItem.test.tsx
+++ b/frontend/src/molecules/NavItem/NavItem.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { NavItem } from './NavItem';
+
+describe('NavItem', () => {
+  it('renders icon and label', () => {
+    render(<NavItem iconName="Home" label="Inicio" />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(screen.getByText('Inicio')).toBeInTheDocument();
+  });
+
+  it('shows badge when enabled and count > 0', () => {
+    render(<NavItem iconName="Mail" label="Mail" showBadge badgeCount={2} />);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('hides badge when count is 0', () => {
+    render(<NavItem iconName="Mail" label="Mail" showBadge badgeCount={0} />);
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('calls onClick handler', () => {
+    const handleClick = vi.fn();
+    render(<NavItem iconName="Home" label="Inicio" onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies active classes', () => {
+    render(<NavItem iconName="Home" label="Inicio" active />);
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('bg-primary');
+  });
+});

--- a/frontend/src/molecules/NavItem/NavItem.tsx
+++ b/frontend/src/molecules/NavItem/NavItem.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { Text } from '@/atoms/Text';
+import { Badge } from '@/atoms/Badge';
+
+const navItemVariants = cva(
+  'flex items-center gap-2 w-full rounded-md px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary',
+  {
+    variants: {
+      active: {
+        true: 'bg-primary text-primary-foreground font-semibold',
+        false: 'text-foreground hover:bg-muted',
+      },
+    },
+    defaultVariants: {
+      active: false,
+    },
+  },
+);
+
+export interface NavItemProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof navItemVariants> {
+  /** Name of the icon to display */
+  iconName: IconName;
+  /** Label for the navigation item */
+  label: string;
+  /** Show badge with count */
+  showBadge?: boolean;
+  /** Number to display inside badge */
+  badgeCount?: number;
+}
+
+export const NavItem = React.forwardRef<HTMLButtonElement, NavItemProps>(
+  (
+    { iconName, label, active, showBadge, badgeCount = 0, className, ...props },
+    ref,
+  ) => {
+    const showBadgeFinal = showBadge && badgeCount > 0;
+
+    return (
+      <button
+        type="button"
+        ref={ref}
+        className={cn(navItemVariants({ active }), className)}
+        {...props}
+      >
+        <Icon name={iconName} size="md" aria-hidden="true" />
+        <Text as="span" className="flex-1 text-left">
+          {label}
+        </Text>
+        {showBadgeFinal && (
+          <Badge variant="info" className="ml-auto">
+            {badgeCount}
+          </Badge>
+        )}
+      </button>
+    );
+  },
+);
+NavItem.displayName = 'NavItem';
+
+export { navItemVariants };

--- a/frontend/src/molecules/NavItem/index.ts
+++ b/frontend/src/molecules/NavItem/index.ts
@@ -1,0 +1,1 @@
+export * from './NavItem';


### PR DESCRIPTION
## Summary
- implement NavItem molecule component
- add Storybook docs and stories
- add unit tests for NavItem

## Testing
- `npm run test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_68792b0a3460832bb7a0fa23d5063ce2