### PR TITLE
Fix iconMap export

### DIFF
--- a/frontend/src/atoms/Icon/index.ts
+++ b/frontend/src/atoms/Icon/index.ts
@@ -1,1 +1,2 @@
 export * from './Icon';
+export * from './icons';


### PR DESCRIPTION
## Summary
- expose iconMap and IconName from atoms/Icon entry point

## Testing
- `pnpm test:frontend`
- `pnpm lint:frontend` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6879349b3990832bb0a3fb9f6c8b2afe