### PR TITLE
Add UserProfile molecule

### DIFF
--- a/frontend/src/molecules/UserProfile/UserProfile.docs.mdx
+++ b/frontend/src/molecules/UserProfile/UserProfile.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { UserProfile } from './UserProfile';
+
+<Meta title="Molecules/UserProfile" of={UserProfile} />
+
+# UserProfile
+
+The `UserProfile` component shows the currently authenticated user with an avatar and name. It can optionally display a dropdown indicator and a status dot.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="flex items-center gap-4">
+      <UserProfile userName="Juan Perez" avatarSrc="https://placehold.co/40" showDropdownIcon />
+      <UserProfile userName="Maria" status="online" showDropdownIcon />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={UserProfile} />

--- a/frontend/src/molecules/UserProfile/UserProfile.stories.tsx
+++ b/frontend/src/molecules/UserProfile/UserProfile.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UserProfile, type UserProfileProps } from './UserProfile';
+
+const meta: Meta<UserProfileProps> = {
+  title: 'Molecules/UserProfile',
+  component: UserProfile,
+  tags: ['autodocs'],
+  argTypes: {
+    userName: { control: 'text' },
+    avatarSrc: { control: 'text' },
+    showDropdownIcon: { control: 'boolean' },
+    status: { control: 'select', options: ['online', 'offline', 'away'] },
+    onClick: { action: 'clicked' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    userName: 'Juan Perez',
+    avatarSrc: 'https://placehold.co/40',
+    showDropdownIcon: true,
+  },
+};
+
+export const WithStatus: Story = {
+  args: {
+    userName: 'Maria Rodriguez',
+    avatarSrc: 'https://placehold.co/40',
+    status: 'online',
+    showDropdownIcon: true,
+  },
+};
+
+export const NoImage: Story = {
+  args: {
+    userName: 'No Avatar',
+    avatarSrc: null,
+    showDropdownIcon: true,
+  },
+};

--- a/frontend/src/molecules/UserProfile/UserProfile.test.tsx
+++ b/frontend/src/molecules/UserProfile/UserProfile.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { UserProfile } from './UserProfile';
+
+describe('UserProfile', () => {
+  it('renders avatar and name', () => {
+    render(<UserProfile userName="John" avatarSrc="avatar.png" />);
+    expect(screen.getByText('John')).toBeInTheDocument();
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'avatar.png');
+  });
+
+  it('falls back to initials when no image', () => {
+    render(<UserProfile userName="Jane Doe" avatarSrc={null} />);
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('shows dropdown icon when enabled', () => {
+    const { container } = render(<UserProfile userName="John" showDropdownIcon />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick handler', () => {
+    const handleClick = vi.fn();
+    render(<UserProfile userName="John" onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/molecules/UserProfile/UserProfile.tsx
+++ b/frontend/src/molecules/UserProfile/UserProfile.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Avatar } from '@/atoms/Avatar';
+import { Text } from '@/atoms/Text';
+import { Icon } from '@/atoms/Icon';
+
+const userProfileVariants = cva(
+  'inline-flex items-center gap-2 rounded-md px-2 py-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary',
+  {
+    variants: {
+      hoverable: {
+        true: 'hover:bg-muted',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      hoverable: true,
+    },
+  },
+);
+
+export interface UserProfileProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof userProfileVariants> {
+  /** User name to display */
+  userName: string;
+  /** Avatar image url */
+  avatarSrc?: string | null;
+  /** Show dropdown indicator icon */
+  showDropdownIcon?: boolean;
+  /** Optional user status indicator */
+  status?: 'online' | 'offline' | 'away';
+}
+
+export const UserProfile = React.forwardRef<HTMLButtonElement, UserProfileProps>(
+  (
+    { userName, avatarSrc, showDropdownIcon = false, status, hoverable, className, ...props },
+    ref,
+  ) => {
+    const statusColor =
+      status === 'online'
+        ? 'bg-success'
+        : status === 'away'
+          ? 'bg-quaternary'
+          : status === 'offline'
+            ? 'bg-muted'
+            : undefined;
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(userProfileVariants({ hoverable }), className)}
+        {...props}
+      >
+        <span className="relative inline-block">
+          <Avatar src={avatarSrc ?? undefined} size="sm" name={userName} />
+          {statusColor && (
+            <span
+              className={cn(
+                'absolute bottom-0 right-0 block h-2 w-2 rounded-full ring-1 ring-background',
+                statusColor,
+              )}
+            />
+          )}
+        </span>
+        <Text as="span" className="max-w-[8rem] truncate">
+          {userName}
+        </Text>
+        {showDropdownIcon && <Icon name="ChevronDown" aria-hidden="true" />}
+      </button>
+    );
+  },
+);
+UserProfile.displayName = 'UserProfile';
+
+export { userProfileVariants };

--- a/frontend/src/molecules/UserProfile/index.ts
+++ b/frontend/src/molecules/UserProfile/index.ts
@@ -1,0 +1,1 @@
+export * from './UserProfile';


### PR DESCRIPTION
## Summary
- create new UserProfile molecule with avatar, name, dropdown icon and optional status
- add Storybook docs and stories for the new component
- include unit tests

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6879361427b8832bbb44c854af3d43b5