### PR TITLE
Add StatCard molecule

### DIFF
--- a/frontend/src/molecules/StatCard/StatCard.docs.mdx
+++ b/frontend/src/molecules/StatCard/StatCard.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { StatCard } from './StatCard';
+
+<Meta title="Molecules/StatCard" of={StatCard} />
+
+# StatCard
+
+The `StatCard` component highlights a single metric or KPI using the `Card` atom. It can optionally display an icon and be made clickable.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="grid grid-cols-2 gap-4 max-w-sm">
+      <StatCard value="120" label="Nuevos Pedidos" iconName="Folder" />
+      <StatCard value="$5,000" label="Ventas" iconName="File" variant="outline" />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={StatCard} />

--- a/frontend/src/molecules/StatCard/StatCard.stories.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatCard, StatCardProps } from './StatCard';
+import { iconMap, type IconName } from '@/atoms/Icon';
+
+interface StatCardStoryProps extends StatCardProps {
+  iconName?: IconName;
+}
+
+const iconOptions = Object.keys(iconMap) as IconName[];
+
+const meta: Meta<StatCardStoryProps> = {
+  title: 'Molecules/StatCard',
+  component: StatCard,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: 'text' },
+    label: { control: 'text' },
+    iconName: { control: 'select', options: iconOptions },
+    variant: { control: 'select', options: ['shadow', 'outline', 'glass'] },
+    clickable: { control: 'boolean' },
+    onClick: { action: 'clicked', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: '120',
+    label: 'Nuevos Pedidos',
+    iconName: 'Folder',
+    variant: 'shadow',
+    clickable: false,
+  },
+};
+
+export const Clickable: Story = {
+  args: {
+    value: '$5,000',
+    label: 'Ventas',
+    iconName: 'File',
+    clickable: true,
+  },
+};

--- a/frontend/src/molecules/StatCard/StatCard.test.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { StatCard } from './StatCard';
+
+describe('StatCard', () => {
+  it('renders value and label', () => {
+    render(<StatCard value="42" label="Test" />);
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+
+  it('shows icon when iconName is provided', () => {
+    const { container } = render(
+      <StatCard value="1" label="Icon" iconName="Home" />,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clickable', () => {
+    const handleClick = vi.fn();
+    render(
+      <StatCard value="10" label="Clickable" clickable onClick={handleClick} />,
+    );
+    fireEvent.click(screen.getByText('10'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('applies clickable styles', () => {
+    render(<StatCard value="5" label="Hover" clickable />);
+    const card = screen.getByText('5').closest('div');
+    expect(card?.className).toContain('cursor-pointer');
+  });
+});

--- a/frontend/src/molecules/StatCard/StatCard.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { Card, type CardProps } from '@/atoms/Card';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { Text } from '@/atoms/Text';
+import { cn } from '@/lib/utils';
+
+const statCardVariants = cva('relative overflow-hidden', {
+  variants: {
+    orientation: {
+      vertical: 'flex flex-col',
+      horizontal: 'flex items-center gap-2',
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+});
+
+export interface StatCardProps
+  extends Omit<CardProps, 'children'>,
+    VariantProps<typeof statCardVariants> {
+  /** Main numeric or textual value */
+  value: string | number;
+  /** Descriptive label for the metric */
+  label: string;
+  /** Optional icon name to display */
+  iconName?: IconName;
+}
+
+export const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
+  (
+    { value, label, iconName, variant, clickable, orientation, className, ...props },
+    ref,
+  ) => {
+    return (
+      <Card
+        ref={ref}
+        variant={variant}
+        clickable={clickable}
+        className={cn(statCardVariants({ orientation }), className)}
+        {...props}
+      >
+        {iconName && (
+          <Icon
+            name={iconName}
+            className="absolute right-3 top-3 h-6 w-6 text-muted-foreground/50"
+            aria-hidden="true"
+          />
+        )}
+        <Text as="span" className="text-3xl font-semibold">
+          {value}
+        </Text>
+        <Text as="span" className="text-sm text-muted-foreground">
+          {label}
+        </Text>
+      </Card>
+    );
+  },
+);
+StatCard.displayName = 'StatCard';
+
+export { statCardVariants };

--- a/frontend/src/molecules/StatCard/index.ts
+++ b/frontend/src/molecules/StatCard/index.ts
@@ -1,0 +1,1 @@
+export * from './StatCard';


### PR DESCRIPTION
## Summary
- add `StatCard` molecule using existing atoms
- include Storybook docs and stories
- provide unit tests for basic behaviour

## Testing
- `pnpm --filter erp_system test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879361f04c8832b9e9f769eb16122ae