### PR TITLE
Add ProductCard molecule

### DIFF
--- a/frontend/src/molecules/ProductCard/ProductCard.docs.mdx
+++ b/frontend/src/molecules/ProductCard/ProductCard.docs.mdx
@@ -1,0 +1,18 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { ProductCard } from './ProductCard';
+
+<Meta title="Molecules/ProductCard" of={ProductCard} />
+
+# ProductCard
+
+La `ProductCard` muestra de forma resumida la información principal de un producto de inventario. Utiliza los átomos existentes para construir una tarjeta con imagen, nombre, precio y estados.
+
+<Canvas>
+  <Story name="Ejemplo">
+    <div className="w-64">
+      <ProductCard productName="Camisa de Lino" price="$49.99" imageSrc="https://via.placeholder.com/300x200" />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={ProductCard} />

--- a/frontend/src/molecules/ProductCard/ProductCard.stories.tsx
+++ b/frontend/src/molecules/ProductCard/ProductCard.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProductCard, ProductCardProps } from './ProductCard';
+
+const meta: Meta<ProductCardProps> = {
+  title: 'Molecules/ProductCard',
+  component: ProductCard,
+  tags: ['autodocs'],
+  argTypes: {
+    productName: { control: 'text' },
+    price: { control: 'text' },
+    imageSrc: { control: 'text' },
+    outOfStock: { control: 'boolean' },
+    onSale: { control: 'boolean' },
+    clickable: { control: 'boolean' },
+    statusBadge: {
+      control: 'select',
+      options: [null, 'Nuevo', 'Oferta', 'Agotado'],
+    },
+    showActions: { control: 'boolean' },
+    onAddToCart: { action: 'addToCart', table: { category: 'Events' } },
+    onEdit: { action: 'editClicked', table: { category: 'Events' } },
+    onDelete: { action: 'deleteClicked', table: { category: 'Events' } },
+    onClick: { action: 'clicked', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    productName: 'Camisa de Lino',
+    price: '$49.99',
+    imageSrc: 'https://via.placeholder.com/300x200',
+    outOfStock: false,
+    onSale: false,
+    clickable: true,
+    statusBadge: null,
+    showActions: false,
+  },
+};
+
+export const WithBadges: Story = {
+  args: {
+    productName: 'Camisa de Lino',
+    price: '$39.99',
+    onSale: true,
+    statusBadge: 'Nuevo',
+  },
+};
+
+export const OutOfStock: Story = {
+  args: {
+    productName: 'Camisa de Lino',
+    price: '$49.99',
+    outOfStock: true,
+    statusBadge: 'Agotado',
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    productName: 'Camisa de Lino',
+    price: '$49.99',
+    showActions: true,
+  },
+};

--- a/frontend/src/molecules/ProductCard/ProductCard.test.tsx
+++ b/frontend/src/molecules/ProductCard/ProductCard.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ProductCard } from './ProductCard';
+
+describe('ProductCard', () => {
+  it('renders product name and price', () => {
+    render(<ProductCard productName="Camisa" price="$10" />);
+    expect(screen.getByText('Camisa')).toBeInTheDocument();
+    expect(screen.getByText('$10')).toBeInTheDocument();
+  });
+
+  it('shows out of stock badge', () => {
+    render(<ProductCard productName="Camisa" price="$10" outOfStock />);
+    expect(screen.getByText('Sin stock')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clickable', () => {
+    const handleClick = vi.fn();
+    render(<ProductCard productName="Camisa" price="$10" onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('calls action handlers', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <ProductCard
+        productName="Camisa"
+        price="$10"
+        showActions
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    // first is card; second etc.
+    fireEvent.click(buttons[1]);
+    expect(onEdit).toHaveBeenCalled();
+    fireEvent.click(buttons[2]);
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/molecules/ProductCard/ProductCard.tsx
+++ b/frontend/src/molecules/ProductCard/ProductCard.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { Card } from '@/atoms/Card';
+import { Heading } from '@/atoms/Heading';
+import { Text } from '@/atoms/Text';
+import { Badge } from '@/atoms/Badge';
+import { Tag } from '@/atoms/Tag';
+import { Button } from '@/atoms/Button/Button';
+import { Icon } from '@/atoms/Icon';
+import { cn } from '@/lib/utils';
+
+export interface ProductCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  productName: string;
+  price: string;
+  imageSrc?: string;
+  outOfStock?: boolean;
+  onSale?: boolean;
+  clickable?: boolean;
+  statusBadge?: 'Nuevo' | 'Oferta' | 'Agotado' | null;
+  showActions?: boolean;
+  onAddToCart?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+const placeholderImg = 'https://via.placeholder.com/300x200?text=Imagen';
+
+export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
+  (
+    {
+      productName,
+      price,
+      imageSrc,
+      outOfStock = false,
+      onSale = false,
+      clickable = true,
+      statusBadge = null,
+      showActions = false,
+      onAddToCart,
+      onEdit,
+      onDelete,
+      onClick,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (clickable && onClick) {
+        onClick();
+      }
+    };
+
+    const imageClasses = cn('h-40 w-full object-cover rounded-md', outOfStock && 'opacity-50');
+
+    const statusColor = statusBadge === 'Agotado'
+      ? 'destructive'
+      : statusBadge === 'Oferta'
+      ? 'secondary'
+      : 'success';
+
+    return (
+      <Card
+        ref={ref}
+        clickable={clickable}
+        onClick={handleClick}
+        role={clickable ? 'button' : undefined}
+        tabIndex={clickable ? 0 : undefined}
+        className={cn('w-full space-y-2', className)}
+        {...props}
+      >
+        <div className="relative">
+          <img
+            src={imageSrc || placeholderImg}
+            alt={productName}
+            className={imageClasses}
+          />
+          {outOfStock && (
+            <Badge variant="destructive" className="absolute top-2 left-2">
+              Sin stock
+            </Badge>
+          )}
+          {onSale && (
+            <Badge variant="info" className="absolute top-2 right-2">
+              Oferta
+            </Badge>
+          )}
+          {showActions && (
+            <div className="absolute bottom-2 right-2 flex gap-1">
+              {onEdit && (
+                <Button
+                  variant="icon"
+                  size="sm"
+                  intent="secondary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEdit();
+                  }}
+                >
+                  <Icon name="Edit" />
+                </Button>
+              )}
+              {onDelete && (
+                <Button
+                  variant="icon"
+                  size="sm"
+                  intent="tertiary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete();
+                  }}
+                >
+                  <Icon name="Trash2" />
+                </Button>
+              )}
+              {onAddToCart && (
+                <Button
+                  variant="icon"
+                  size="sm"
+                  intent="primary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAddToCart();
+                  }}
+                >
+                  <Icon name="Plus" />
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex items-start justify-between gap-2">
+          <Heading level={4} className="flex-1 text-sm truncate">
+            {productName}
+          </Heading>
+          <Text as="span" weight="semibold" color="secondary">
+            {price}
+          </Text>
+        </div>
+        {statusBadge && (
+          <Tag variant="solid" color={statusColor} className="text-xs">
+            {statusBadge}
+          </Tag>
+        )}
+      </Card>
+    );
+  },
+);
+ProductCard.displayName = 'ProductCard';
+
+

--- a/frontend/src/molecules/ProductCard/index.ts
+++ b/frontend/src/molecules/ProductCard/index.ts
@@ -1,0 +1,1 @@
+export * from './ProductCard';


### PR DESCRIPTION
## Summary
- add ProductCard molecule using existing atoms
- document ProductCard in Storybook
- add story and unit tests

## Testing
- `pnpm --filter erp_system exec vitest run src/molecules/ProductCard/ProductCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6879362bcdec832b9a347b01e1dc37ac