### PR TITLE
Add OrderListItem molecule

### DIFF
--- a/frontend/src/molecules/OrderListItem/OrderListItem.docs.mdx
+++ b/frontend/src/molecules/OrderListItem/OrderListItem.docs.mdx
@@ -1,0 +1,22 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { OrderListItem } from './OrderListItem';
+
+<Meta title="Molecules/OrderListItem" of={OrderListItem} />
+
+# OrderListItem
+
+The `OrderListItem` component represents a single order in a list. It displays the main details and the current status of the order.
+
+<Canvas>
+  <Story name="Examples">
+    <OrderListItem
+      orderId="1001"
+      date="01/09/2025"
+      customerName="Juan Perez"
+      total="$250.00"
+      status="Pendiente"
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={OrderListItem} />

--- a/frontend/src/molecules/OrderListItem/OrderListItem.stories.tsx
+++ b/frontend/src/molecules/OrderListItem/OrderListItem.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OrderListItem, OrderListItemProps } from './OrderListItem';
+
+const meta: Meta<OrderListItemProps> = {
+  title: 'Molecules/OrderListItem',
+  component: OrderListItem,
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['Pendiente', 'Enviado', 'Entregado', 'Cancelado'],
+    },
+    orderId: { control: 'text' },
+    date: { control: 'text' },
+    customerName: { control: 'text' },
+    total: { control: 'text' },
+    showActions: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+    onActionSelect: { action: 'action selected' },
+    onStatusClick: { action: 'status clicked' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    orderId: '1001',
+    date: '01/09/2025',
+    customerName: 'Juan Perez',
+    total: '$250.00',
+    status: 'Pendiente',
+    showActions: false,
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    orderId: '1001',
+    date: '01/09/2025',
+    customerName: 'Juan Perez',
+    total: '$250.00',
+    status: 'Pendiente',
+    showActions: true,
+  },
+};

--- a/frontend/src/molecules/OrderListItem/OrderListItem.test.tsx
+++ b/frontend/src/molecules/OrderListItem/OrderListItem.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { OrderListItem } from './OrderListItem';
+
+const baseProps = {
+  orderId: '1001',
+  date: '01/09/2025',
+  customerName: 'Juan Perez',
+  total: '$250.00',
+  status: 'Pendiente',
+};
+
+describe('OrderListItem', () => {
+  it('renders order information', () => {
+    render(<OrderListItem {...baseProps} />);
+    expect(screen.getByText('#1001')).toBeInTheDocument();
+    expect(screen.getByText('Juan Perez')).toBeInTheDocument();
+    expect(screen.getByText('$250.00')).toBeInTheDocument();
+  });
+
+  it('shows action button when enabled', () => {
+    render(<OrderListItem {...baseProps} showActions />);
+    expect(screen.getByLabelText('Acciones')).toBeInTheDocument();
+  });
+
+  it('calls onClick handler', () => {
+    const handleClick = vi.fn();
+    render(<OrderListItem {...baseProps} onClick={handleClick} />);
+    fireEvent.click(screen.getByText('#1001'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onActionSelect when action button clicked', () => {
+    const handleAction = vi.fn();
+    render(
+      <OrderListItem {...baseProps} showActions onActionSelect={handleAction} />,
+    );
+    fireEvent.click(screen.getByLabelText('Acciones'));
+    expect(handleAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps status to badge variant', () => {
+    render(<OrderListItem {...baseProps} status="Entregado" />);
+    const badge = screen.getByText('Entregado');
+    expect(badge.className).toContain('bg-success');
+  });
+
+  it('calls onStatusClick when badge clicked', () => {
+    const handleStatus = vi.fn();
+    render(<OrderListItem {...baseProps} onStatusClick={handleStatus} />);
+    fireEvent.click(screen.getByText('Pendiente'));
+    expect(handleStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/molecules/OrderListItem/OrderListItem.tsx
+++ b/frontend/src/molecules/OrderListItem/OrderListItem.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Text } from '@/atoms/Text';
+import { Badge, type BadgeProps } from '@/atoms/Badge';
+import { Button } from '@/atoms/Button/Button';
+import { Icon } from '@/atoms/Icon';
+
+const orderListItemVariants = cva(
+  'grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-2 px-3 py-2 text-sm rounded-md',
+  {
+    variants: {
+      clickable: {
+        true: 'hover:bg-muted cursor-pointer',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      clickable: true,
+    },
+  },
+);
+
+const statusColorMap: Record<string, BadgeProps['variant']> = {
+  Pendiente: 'warning',
+  Enviado: 'info',
+  Entregado: 'success',
+  Cancelado: 'destructive',
+};
+
+export interface OrderListItemProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof orderListItemVariants> {
+  orderId: string;
+  date: string;
+  customerName: string;
+  total: string;
+  status: string;
+  showActions?: boolean;
+  onActionSelect?: () => void;
+  onStatusClick?: () => void;
+}
+
+export const OrderListItem = React.forwardRef<HTMLDivElement, OrderListItemProps>(
+  (
+    {
+      orderId,
+      date,
+      customerName,
+      total,
+      status,
+      showActions,
+      clickable,
+      className,
+      onClick,
+      onActionSelect,
+      onStatusClick,
+      ...props
+    },
+    ref,
+  ) => {
+    const statusVariant = statusColorMap[status] ?? 'neutral';
+
+    const handleActionClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onActionSelect?.();
+    };
+
+    const handleStatusClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onStatusClick?.();
+    };
+
+    return (
+      <div
+        ref={ref}
+        className={cn(orderListItemVariants({ clickable }), className)}
+        onClick={onClick}
+        {...props}
+      >
+        <Text as="span" weight="semibold" className="w-20">
+          #{orderId}
+        </Text>
+        <Text as="span" className="w-24 hidden sm:inline">
+          {date}
+        </Text>
+        <Text as="span" className="truncate">
+          {customerName}
+        </Text>
+        <Text as="span" weight="medium" className="w-24 text-right">
+          {total}
+        </Text>
+        <Badge
+          variant={statusVariant}
+          onClick={onStatusClick ? handleStatusClick : undefined}
+          className={cn(onStatusClick && 'cursor-pointer select-none')}
+        >
+          {status}
+        </Badge>
+        {showActions && (
+          <Button
+            variant="icon"
+            intent="secondary"
+            size="sm"
+            aria-label="Acciones"
+            onClick={handleActionClick}
+            className="ml-1"
+          >
+            <Icon name="MoreHorizontal" />
+          </Button>
+        )}
+      </div>
+    );
+  },
+);
+OrderListItem.displayName = 'OrderListItem';
+
+export { orderListItemVariants };

--- a/frontend/src/molecules/OrderListItem/index.ts
+++ b/frontend/src/molecules/OrderListItem/index.ts
@@ -1,0 +1,1 @@
+export * from './OrderListItem';


### PR DESCRIPTION
## Summary
- add new OrderListItem molecule
- document OrderListItem in Storybook
- add stories for OrderListItem
- test OrderListItem behavior

## Testing
- `pnpm test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_687936363b28832b937f8bbb28e57354