### PR TITLE
Add PaginationControls molecule

### DIFF
--- a/frontend/src/molecules/PaginationControls/PaginationControls.docs.mdx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { PaginationControls } from './PaginationControls';
+
+<Meta title="Molecules/PaginationControls" of={PaginationControls} />
+
+# PaginationControls
+
+The `PaginationControls` component provides buttons for navigating between pages of results.
+
+<Canvas>
+  <Story name="Example">
+    <PaginationControls currentPage={3} totalPages={10} onPageChange={(page) => console.log(page)} />
+  </Story>
+</Canvas>
+
+<ArgsTable of={PaginationControls} />

--- a/frontend/src/molecules/PaginationControls/PaginationControls.stories.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PaginationControls, PaginationControlsProps } from './PaginationControls';
+
+const meta: Meta<PaginationControlsProps> = {
+  title: 'Molecules/PaginationControls',
+  component: PaginationControls,
+  tags: ['autodocs'],
+  argTypes: {
+    currentPage: { control: 'number' },
+    totalPages: { control: 'number' },
+    siblings: { control: 'number' },
+    showFirstLast: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    onPageChange: { action: 'page changed' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    currentPage: 1,
+    totalPages: 5,
+  },
+};
+
+export const ManyPages: Story = {
+  args: {
+    currentPage: 5,
+    totalPages: 20,
+    siblings: 1,
+    showFirstLast: true,
+  },
+};

--- a/frontend/src/molecules/PaginationControls/PaginationControls.test.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PaginationControls } from './PaginationControls';
+
+describe('PaginationControls', () => {
+  it('renders page buttons', () => {
+    render(<PaginationControls currentPage={2} totalPages={5} />);
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '5' })).toBeInTheDocument();
+  });
+
+  it('disables prev/next on edges', () => {
+    render(<PaginationControls currentPage={1} totalPages={3} />);
+    const prev = screen.getByLabelText('Previous page');
+    expect(prev).toBeDisabled();
+    const next = screen.getByLabelText('Next page');
+    expect(next).not.toBeDisabled();
+  });
+
+  it('calls onPageChange when number clicked', () => {
+    const handle = vi.fn();
+    render(
+      <PaginationControls currentPage={1} totalPages={3} onPageChange={handle} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    expect(handle).toHaveBeenCalledWith(2);
+  });
+
+  it('shows dots when many pages', () => {
+    render(
+      <PaginationControls currentPage={5} totalPages={20} siblings={1} />,
+    );
+    expect(screen.getAllByText('...').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/molecules/PaginationControls/PaginationControls.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import { Button } from '@/atoms/Button/Button';
+import { Icon } from '@/atoms/Icon';
+import { cn } from '@/lib/utils';
+
+export interface PaginationControlsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Current active page (1-indexed) */
+  currentPage: number;
+  /** Total number of pages */
+  totalPages: number;
+  /** Number of sibling pages to show around the current page */
+  siblings?: number;
+  /** Show buttons for first and last page */
+  showFirstLast?: boolean;
+  /** Disable all controls */
+  disabled?: boolean;
+  /** Callback fired when page changes */
+  onPageChange?: (page: number) => void;
+}
+
+type PageItem = number | 'dots';
+
+function getPageRange(total: number, current: number, siblings: number): PageItem[] {
+  const range: PageItem[] = [];
+  const totalNumbers = siblings * 2 + 3; // current, siblings on both sides, first and last
+  const totalBlocks = totalNumbers + 2; // with two dots
+
+  if (total <= totalBlocks) {
+    for (let i = 1; i <= total; i++) range.push(i);
+    return range;
+  }
+
+  const leftSiblingIndex = Math.max(current - siblings, 2);
+  const rightSiblingIndex = Math.min(current + siblings, total - 1);
+
+  const showLeftDots = leftSiblingIndex > 2;
+  const showRightDots = rightSiblingIndex < total - 1;
+
+  range.push(1);
+  if (showLeftDots) range.push('dots');
+
+  for (let i = leftSiblingIndex; i <= rightSiblingIndex; i++) {
+    range.push(i);
+  }
+
+  if (showRightDots) range.push('dots');
+  range.push(total);
+  return range;
+}
+
+export const PaginationControls = React.forwardRef<HTMLDivElement, PaginationControlsProps>(
+  (
+    {
+      currentPage,
+      totalPages,
+      siblings = 1,
+      showFirstLast = false,
+      disabled = false,
+      onPageChange,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const handleChange = (page: number) => {
+      if (page === currentPage || page < 1 || page > totalPages) return;
+      onPageChange?.(page);
+    };
+
+    const pages = React.useMemo(
+      () => getPageRange(totalPages, currentPage, siblings),
+      [totalPages, currentPage, siblings],
+    );
+
+    const buttonVariant = 'ghost';
+
+    return (
+      <div ref={ref} className={cn('flex items-center justify-center gap-2', className)} {...props}>
+        {showFirstLast && (
+          <Button
+            variant={buttonVariant}
+            size="sm"
+            disabled={disabled || currentPage === 1}
+            onClick={() => handleChange(1)}
+            aria-label="First page"
+          >
+            <Icon name="ChevronLeft" className="-mr-1 rotate-180" />
+            <Icon name="ChevronLeft" />
+          </Button>
+        )}
+        <Button
+          variant={buttonVariant}
+          size="sm"
+          disabled={disabled || currentPage === 1}
+          onClick={() => handleChange(currentPage - 1)}
+          aria-label="Previous page"
+        >
+          <Icon name="ChevronLeft" />
+        </Button>
+        {pages.map((page, idx) =>
+          page === 'dots' ? (
+            <span key={`dots-${idx}`} className="px-2 text-sm">
+              ...
+            </span>
+          ) : (
+            <Button
+              key={page}
+              variant={page === currentPage ? 'default' : buttonVariant}
+              intent="primary"
+              size="sm"
+              disabled={disabled}
+              onClick={() => handleChange(page)}
+              aria-current={page === currentPage ? 'page' : undefined}
+            >
+              {page}
+            </Button>
+          ),
+        )}
+        <Button
+          variant={buttonVariant}
+          size="sm"
+          disabled={disabled || currentPage === totalPages}
+          onClick={() => handleChange(currentPage + 1)}
+          aria-label="Next page"
+        >
+          <Icon name="ChevronRight" />
+        </Button>
+        {showFirstLast && (
+          <Button
+            variant={buttonVariant}
+            size="sm"
+            disabled={disabled || currentPage === totalPages}
+            onClick={() => handleChange(totalPages)}
+            aria-label="Last page"
+          >
+            <Icon name="ChevronRight" />
+            <Icon name="ChevronRight" className="-ml-1" />
+          </Button>
+        )}
+      </div>
+    );
+  },
+);
+PaginationControls.displayName = 'PaginationControls';
+
+

--- a/frontend/src/molecules/PaginationControls/index.ts
+++ b/frontend/src/molecules/PaginationControls/index.ts
@@ -1,0 +1,1 @@
+export * from './PaginationControls';


### PR DESCRIPTION
## Summary
- create PaginationControls molecule for navigating paginated lists
- document component with MDX
- add Storybook stories
- provide unit tests

## Testing
- `pnpm --filter erp_system exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6879365cff60832b911a677256ba5edb