### PR TITLE
Add DropdownMenu molecule

### DIFF
--- a/frontend/src/molecules/DropdownMenu/DropdownMenu.docs.mdx
+++ b/frontend/src/molecules/DropdownMenu/DropdownMenu.docs.mdx
@@ -1,0 +1,22 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { DropdownMenu } from './DropdownMenu';
+
+<Meta title="Molecules/DropdownMenu" of={DropdownMenu} />
+
+# DropdownMenu
+
+The `DropdownMenu` component displays a floating list of actions triggered by a button. Use it for contextual options like user menus or row actions.
+
+<Canvas>
+  <Story name="Example">
+    <DropdownMenu
+      triggerLabel="User"
+      items={[
+        { label: 'View Profile', iconName: 'User' },
+        { label: 'Logout', iconName: 'LogOut' },
+      ]}
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={DropdownMenu} />

--- a/frontend/src/molecules/DropdownMenu/DropdownMenu.stories.tsx
+++ b/frontend/src/molecules/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DropdownMenu, DropdownMenuProps } from './DropdownMenu';
+
+const meta: Meta<DropdownMenuProps> = {
+  title: 'Molecules/DropdownMenu',
+  component: DropdownMenu,
+  tags: ['autodocs'],
+  argTypes: {
+    triggerLabel: { control: 'text' },
+    items: { control: 'object' },
+    placement: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
+    align: { control: 'select', options: ['start', 'center', 'end'] },
+    open: { control: 'boolean' },
+    onSelect: { action: 'select', table: { category: 'Events' } },
+    onOpenChange: { action: 'openChange', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    triggerLabel: 'Options',
+    items: [
+      { label: 'Edit', iconName: 'Edit' },
+      { label: 'Delete', iconName: 'Trash2' },
+    ],
+  },
+};

--- a/frontend/src/molecules/DropdownMenu/DropdownMenu.test.tsx
+++ b/frontend/src/molecules/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DropdownMenu } from './DropdownMenu';
+
+const items = [
+  { label: 'Edit', iconName: 'Edit' as const },
+  { label: 'Delete', iconName: 'Trash2' as const },
+];
+
+describe('DropdownMenu', () => {
+  it('opens when trigger clicked', () => {
+    render(<DropdownMenu triggerLabel="Open" items={items} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+  });
+
+  it('calls onSelect and closes', () => {
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu triggerLabel="Menu" items={items} onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('Edit'));
+    expect(onSelect).toHaveBeenCalledWith(items[0]);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('does not select disabled item', () => {
+    const onSelect = vi.fn();
+    const disabled = [{ label: 'Edit', disabled: true }];
+    render(
+      <DropdownMenu triggerLabel="Menu" items={disabled} onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('Edit'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('closes when clicking outside', () => {
+    render(<DropdownMenu triggerLabel="Menu" items={items} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.click(document.body);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/molecules/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/molecules/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { Button } from '@/atoms/Button/Button';
+import { cn } from '@/lib/utils';
+
+export interface DropdownMenuItem {
+  label: string;
+  iconName?: IconName;
+  disabled?: boolean;
+  id?: string | number;
+}
+
+export interface DropdownMenuProps {
+  /** Content for the trigger button */
+  triggerLabel: React.ReactNode;
+  /** List of menu items */
+  items: DropdownMenuItem[];
+  /** Placement of the menu relative to the trigger */
+  placement?: 'top' | 'bottom' | 'left' | 'right';
+  /** Alignment relative to the trigger */
+  align?: 'start' | 'center' | 'end';
+  /** Controlled open state */
+  open?: boolean;
+  /** Callback when an option is selected */
+  onSelect?: (item: DropdownMenuItem) => void;
+  /** Callback when menu opens/closes */
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+export const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  triggerLabel,
+  items,
+  placement = 'bottom',
+  align = 'start',
+  open,
+  onSelect,
+  onOpenChange,
+  className,
+}) => {
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+  const [style, setStyle] = React.useState<React.CSSProperties>();
+
+  const updatePosition = React.useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const spacing = 4;
+    let top = 0;
+    let left = 0;
+
+    switch (placement) {
+      case 'top':
+        top = rect.top - spacing;
+        break;
+      case 'bottom':
+        top = rect.bottom + spacing;
+        break;
+      case 'left':
+        top = rect.top;
+        left = rect.left - spacing;
+        break;
+      case 'right':
+        top = rect.top;
+        left = rect.right + spacing;
+        break;
+      default:
+        top = rect.bottom + spacing;
+    }
+
+    if (placement === 'top' || placement === 'bottom') {
+      if (align === 'start') {
+        left = rect.left;
+      } else if (align === 'center') {
+        left = rect.left + rect.width / 2;
+      } else {
+        left = rect.right;
+      }
+    } else {
+      // left or right placement
+      if (align === 'start') {
+        top = rect.top;
+      } else if (align === 'center') {
+        top = rect.top + rect.height / 2;
+      } else {
+        top = rect.bottom;
+      }
+    }
+
+    let transform = '';
+    if (placement === 'top') {
+      transform = align === 'center' ? 'translate(-50%, -100%)' : 'translate(0, -100%)';
+    } else if (placement === 'bottom') {
+      transform = align === 'center' ? 'translate(-50%, 0)' : 'translate(0, 0)';
+    } else if (placement === 'left') {
+      transform = align === 'center' ? 'translate(-100%, -50%)' : 'translate(-100%, 0)';
+    } else {
+      transform = align === 'center' ? 'translate(0, -50%)' : 'translate(0, 0)';
+    }
+
+    setStyle({ top, left, transform });
+  }, [placement, align]);
+
+  const toggleOpen = () => {
+    const newOpen = !isOpen;
+    if (!isControlled) setInternalOpen(newOpen);
+    onOpenChange?.(newOpen);
+  };
+
+  const close = () => {
+    if (!isControlled) setInternalOpen(false);
+    onOpenChange?.(false);
+  };
+
+  const handleSelect = (item: DropdownMenuItem) => {
+    if (item.disabled) return;
+    onSelect?.(item);
+    close();
+  };
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    updatePosition();
+    const handleClick = (e: MouseEvent) => {
+      if (!triggerRef.current) return;
+      if (!triggerRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('click', handleClick);
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('click', handleClick);
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [isOpen, updatePosition]);
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        ref={triggerRef}
+        onClick={toggleOpen}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+      >
+        {triggerLabel}
+      </Button>
+      {isOpen &&
+        createPortal(
+          <div
+            role="menu"
+            style={style}
+            className={cn(
+              'absolute z-50 min-w-[8rem] rounded-md border border-border bg-white shadow-md',
+              className,
+            )}
+          >
+            {items.map((item) => (
+              <button
+                key={item.id ?? item.label}
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={() => handleSelect(item)}
+                className={cn(
+                  'flex w-full items-center gap-2 px-3 py-2 text-sm text-left hover:bg-muted disabled:opacity-50',
+                )}
+              >
+                {item.iconName && <Icon name={item.iconName} size="sm" aria-hidden="true" />}
+                <span className="flex-1">{item.label}</span>
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+};
+
+DropdownMenu.displayName = 'DropdownMenu';

--- a/frontend/src/molecules/DropdownMenu/index.ts
+++ b/frontend/src/molecules/DropdownMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './DropdownMenu';


### PR DESCRIPTION
## Summary
- implement DropdownMenu molecule with trigger and portal-based menu
- add Storybook docs and stories for DropdownMenu
- create DropdownMenu unit tests

## Testing
- `pnpm test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_6879366bead8832bb72ff5dd634ff714