### PR TITLE
Add FileUploader molecule

### DIFF
--- a/frontend/src/molecules/FileUploader/FileUploader.docs.mdx
+++ b/frontend/src/molecules/FileUploader/FileUploader.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { FileUploader } from './FileUploader';
+
+<Meta title="Molecules/FileUploader" of={FileUploader} />
+
+# FileUploader
+
+The `FileUploader` component provides a drag and drop area with image preview and remove option.
+
+<Canvas>
+  <Story name="Example">
+    <FileUploader />
+  </Story>
+</Canvas>
+
+<ArgsTable of={FileUploader} />

--- a/frontend/src/molecules/FileUploader/FileUploader.stories.tsx
+++ b/frontend/src/molecules/FileUploader/FileUploader.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FileUploader, FileUploaderProps } from './FileUploader';
+
+const meta: Meta<FileUploaderProps> = {
+  title: 'Molecules/FileUploader',
+  component: FileUploader,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: 'text' },
+    label: { control: 'text' },
+    multiple: { control: 'boolean' },
+    accept: { control: 'text' },
+    disabled: { control: 'boolean' },
+    onFileSelect: { action: 'file selected', table: { category: 'Events' } },
+    onFileRemove: { action: 'file removed', table: { category: 'Events' } },
+    onDrop: { action: 'dropped', table: { category: 'Events' } },
+    onError: { action: 'error', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/frontend/src/molecules/FileUploader/FileUploader.test.tsx
+++ b/frontend/src/molecules/FileUploader/FileUploader.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { FileUploader } from './FileUploader';
+
+const createFile = (name: string, type = 'image/png') => new File(['hello'], name, { type });
+
+const dropFile = (node: HTMLElement, file: File) => {
+  const data = { files: [file] } as DataTransfer;
+  fireEvent.drop(node, { dataTransfer: data });
+};
+
+beforeAll(() => {
+  (global as any).URL.createObjectURL = vi.fn(() => "preview");
+});
+describe('FileUploader', () => {
+  it('renders label text', () => {
+    render(<FileUploader label="Upload" />);
+    expect(screen.getByText('Upload')).toBeInTheDocument();
+  });
+
+  it('shows image preview after selecting file', () => {
+    render(<FileUploader />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('img.png')] } });
+    expect(screen.getByAltText('preview')).toBeInTheDocument();
+  });
+
+  it('removes file when clicking remove button', () => {
+    render(<FileUploader />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('img.png')] } });
+    fireEvent.click(screen.getByLabelText('Eliminar archivo'));
+    expect(screen.queryByAltText('preview')).not.toBeInTheDocument();
+  });
+
+  it('calls onDrop when file dropped', () => {
+    const handleDrop = vi.fn();
+    render(<FileUploader onDrop={handleDrop} />);
+    const area = screen.getByRole('button');
+    dropFile(area, createFile('img.png'));
+    expect(handleDrop).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/molecules/FileUploader/FileUploader.tsx
+++ b/frontend/src/molecules/FileUploader/FileUploader.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { Card } from '@/atoms/Card';
+import { Icon } from '@/atoms/Icon';
+import { Button } from '@/atoms/Button/Button';
+import { cn } from '@/lib/utils';
+
+export interface FileUploaderProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange' | 'value'> {
+  /** Preview url or initial file */
+  value?: string;
+  /** Instruction label */
+  label?: string;
+  /** Allow selecting multiple files */
+  multiple?: boolean;
+  /** Disabled state */
+  disabled?: boolean;
+  /** Called when a file is selected */
+  onFileSelect?: (files: FileList) => void;
+  /** Called when file is removed */
+  onFileRemove?: () => void;
+  /** Called when dropping files */
+  onDrop?: (files: FileList) => void;
+  /** Called when dropping invalid file */
+  onError?: (message: string) => void;
+}
+
+export const FileUploader = React.forwardRef<HTMLInputElement, FileUploaderProps>(
+  (
+    {
+      value,
+      label = 'Arrastra una imagen aquí o haz clic para seleccionar',
+      multiple = false,
+      disabled = false,
+      accept,
+      onFileSelect,
+      onFileRemove,
+      onDrop: onDropProp,
+      onError,
+      ...props
+    },
+    ref,
+  ) => {
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+    const [preview, setPreview] = React.useState<string | null>(value ?? null);
+    const [isDragging, setDragging] = React.useState(false);
+
+    React.useEffect(() => {
+      setPreview(value ?? null);
+    }, [value]);
+
+    const handleFiles = (files: FileList) => {
+      if (!files || files.length === 0) return;
+      const file = files[0];
+      if (accept && file.type && !file.type.match(accept.replace('*', '.*'))) {
+        onError?.('Tipo de archivo no permitido');
+        return;
+      }
+      const url = URL.createObjectURL(file);
+      setPreview(url);
+      onFileSelect?.(files);
+    };
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      if (e.target.files) {
+        handleFiles(e.target.files);
+      }
+    };
+
+    const handleDrop: React.DragEventHandler<HTMLDivElement> = (e) => {
+      e.preventDefault();
+      if (disabled) return;
+      setDragging(false);
+      const files = e.dataTransfer.files;
+      if (files && files.length > 0) {
+        onDropProp?.(files);
+        handleFiles(files);
+      }
+    };
+
+    const openFileDialog = () => {
+      if (!disabled) {
+        inputRef.current?.click();
+      }
+    };
+
+    const handleRemove = (ev: React.MouseEvent) => {
+      ev.stopPropagation();
+      setPreview(null);
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+      onFileRemove?.();
+    };
+
+    return (
+      <Card
+        variant="outline"
+        className={cn(
+          'relative flex h-40 w-full cursor-pointer items-center justify-center border-2 border-dashed',
+          isDragging && 'border-primary',
+          disabled && 'pointer-events-none opacity-50',
+        )}
+        role="button"
+        aria-disabled={disabled}
+        onClick={openFileDialog}
+        onDragOver={(e) => {
+          e.preventDefault();
+        }}
+        onDragEnter={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={(e) => {
+          e.preventDefault();
+          setDragging(false);
+        }}
+        onDrop={handleDrop}
+      >
+        <input
+          type="file"
+          ref={inputRef}
+          className="hidden"
+          multiple={multiple}
+          accept={accept}
+          onChange={handleChange}
+          disabled={disabled}
+          {...props}
+        />
+        {!preview ? (
+          <div className="flex flex-col items-center text-center pointer-events-none space-y-1">
+            <Icon name="Upload" size="lg" />
+            <p className="text-sm text-muted-foreground">{label}</p>
+          </div>
+        ) : (
+          <>
+            <img src={preview} alt="preview" className="absolute inset-0 h-full w-full rounded-md object-cover" />
+            <Button
+              type="button"
+              variant="icon"
+              intent="secondary"
+              size="sm"
+              aria-label="Eliminar archivo"
+              className="absolute right-1 top-1 z-10"
+              onClick={handleRemove}
+            >
+              <Icon name="X" size="sm" />
+            </Button>
+          </>
+        )}
+      </Card>
+    );
+  },
+);
+FileUploader.displayName = 'FileUploader';
+

--- a/frontend/src/molecules/FileUploader/index.ts
+++ b/frontend/src/molecules/FileUploader/index.ts
@@ -1,0 +1,1 @@
+export * from './FileUploader';


### PR DESCRIPTION
## Summary
- implement `FileUploader` molecule for drag/drop image upload
- create Storybook story and docs
- add unit tests covering upload, removal and drop events

## Testing
- `pnpm --filter erp_system test --run`
- `pnpm --filter erp_system lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68793675d114832b9a1ad4b47bd5f496