### PR TITLE
Add TagInput component

### DIFF
--- a/frontend/src/molecules/TagInput/TagInput.docs.mdx
+++ b/frontend/src/molecules/TagInput/TagInput.docs.mdx
@@ -1,0 +1,17 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { TagInput } from './TagInput';
+
+<Meta title="Molecules/TagInput" of={TagInput} />
+
+# TagInput
+
+The `TagInput` component allows users to enter multiple tags in a single field. Each tag is displayed as a closable chip inside the input.
+
+<Canvas>
+  <Story name="Ejemplo">
+    {() => <TagInput placeholder="Agregar etiquetas..." />}
+  </Story>
+</Canvas>
+
+<ArgsTable of={TagInput} />

--- a/frontend/src/molecules/TagInput/TagInput.stories.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { TagInput, TagInputProps } from './TagInput';
+
+const meta: Meta<TagInputProps> = {
+  title: 'Molecules/TagInput',
+  component: TagInput,
+  tags: ['autodocs'],
+  argTypes: {
+    tags: { control: 'object' },
+    placeholder: { control: 'text' },
+    maxTags: { control: 'number' },
+    separators: { control: 'text' },
+    tagColor: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+    },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+    },
+    disabled: { control: 'boolean' },
+    onTagAdd: { action: 'tag added', table: { category: 'Events' } },
+    onTagRemove: { action: 'tag removed', table: { category: 'Events' } },
+    onChange: { action: 'changed', table: { category: 'Events' } },
+    onInput: { action: 'input', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { placeholder: 'Agregar etiquetas...' },
+};
+
+export const WithInitialTags: Story = {
+  args: {
+    tags: ['react', 'design'],
+    placeholder: 'Agregar etiquetas...',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    tags: ['no-editable'],
+    disabled: true,
+  },
+};
+
+export const Limited: Story = {
+  args: {
+    maxTags: 3,
+    placeholder: 'Máximo 3',
+  },
+};

--- a/frontend/src/molecules/TagInput/TagInput.test.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TagInput } from './TagInput';
+
+describe('TagInput', () => {
+  it('renders initial tags', () => {
+    render(<TagInput tags={['one', 'two']} />);
+    expect(screen.getByText('one')).toBeInTheDocument();
+    expect(screen.getByText('two')).toBeInTheDocument();
+  });
+
+  it('adds tag on enter', () => {
+    render(<TagInput placeholder="add" />);
+    const input = screen.getByPlaceholderText('add');
+    fireEvent.change(input, { target: { value: 'new' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByText('new')).toBeInTheDocument();
+  });
+
+  it('removes tag when close clicked', () => {
+    render(<TagInput tags={['remove']} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('remove')).not.toBeInTheDocument();
+  });
+
+  it('respects maxTags', () => {
+    render(<TagInput maxTags={1} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.change(input, { target: { value: 'b' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.queryByText('b')).not.toBeInTheDocument();
+  });
+
+  it('removes last tag with backspace', () => {
+    render(<TagInput tags={['last']} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.keyDown(input, { key: 'Backspace' });
+    expect(screen.queryByText('last')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/molecules/TagInput/TagInput.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import { type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Tag, tagVariants } from '@/atoms/Tag';
+import { inputVariants } from '@/atoms/Input/Input';
+
+export interface TagInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'value' | 'onChange'>,
+    Pick<VariantProps<typeof inputVariants>, 'size' | 'color'> {
+  /** Initial tags */
+  tags?: string[];
+  /** Placeholder when empty */
+  placeholder?: string;
+  /** Characters that create a new tag */
+  separators?: string;
+  /** Maximum number of tags allowed */
+  maxTags?: number;
+  /** Color variant for tags */
+  tagColor?: VariantProps<typeof tagVariants>['color'];
+  /** Disable input */
+  disabled?: boolean;
+  /** Callback when tag is added */
+  onTagAdd?: (tag: string) => void;
+  /** Callback when tag is removed */
+  onTagRemove?: (tag: string, index: number) => void;
+  /** Callback when tags change */
+  onChange?: (tags: string[]) => void;
+}
+
+export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
+  (
+    {
+      tags: initialTags = [],
+      placeholder,
+      separators = ',',
+      maxTags,
+      tagColor = 'secondary',
+      size,
+      color,
+      disabled,
+      className,
+      onTagAdd,
+      onTagRemove,
+      onChange,
+      onInput,
+      ...props
+    },
+    ref,
+  ) => {
+    const [tags, setTags] = React.useState<string[]>(initialTags);
+    const [inputValue, setInputValue] = React.useState('');
+    const inputRef = React.useRef<HTMLInputElement>(null);
+
+    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+    React.useEffect(() => {
+      setTags(initialTags);
+    }, [initialTags]);
+
+    const addTag = React.useCallback(
+      (value: string) => {
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        if (maxTags && tags.length >= maxTags) return;
+        if (tags.includes(trimmed)) return;
+        const newTags = [...tags, trimmed];
+        setTags(newTags);
+        onTagAdd?.(trimmed);
+        onChange?.(newTags);
+        setInputValue('');
+      },
+      [tags, maxTags, onTagAdd, onChange],
+    );
+
+    const removeTag = React.useCallback(
+      (index: number) => {
+        const removed = tags[index];
+        const newTags = tags.filter((_, i) => i !== index);
+        setTags(newTags);
+        onTagRemove?.(removed, index);
+        onChange?.(newTags);
+      },
+      [tags, onTagRemove, onChange],
+    );
+
+    const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+      if (e.key === 'Enter' || separators.includes(e.key)) {
+        e.preventDefault();
+        addTag(inputValue);
+      } else if (e.key === 'Backspace' && inputValue === '') {
+        removeTag(tags.length - 1);
+      }
+    };
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      setInputValue(e.target.value);
+      onInput?.(e);
+    };
+
+    return (
+      <div
+        className={cn(
+          'flex flex-wrap items-center gap-1 cursor-text',
+          inputVariants({ size, color }),
+          disabled && 'opacity-50 cursor-not-allowed',
+          className,
+        )}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {tags.map((tag, i) => (
+          <Tag
+            key={`${tag}-${i}`}
+            color={tagColor}
+            closable={!disabled}
+            onRemove={() => removeTag(i)}
+            className="mb-1"
+          >
+            {tag}
+          </Tag>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          disabled={disabled}
+          value={inputValue}
+          onKeyDown={handleKeyDown}
+          onChange={handleChange}
+          placeholder={tags.length === 0 ? placeholder : undefined}
+          className="m-1 flex-1 bg-transparent focus:outline-none"
+          {...props}
+        />
+      </div>
+    );
+  },
+);
+TagInput.displayName = 'TagInput';
+
+export { TagInput };

--- a/frontend/src/molecules/TagInput/index.ts
+++ b/frontend/src/molecules/TagInput/index.ts
@@ -1,0 +1,1 @@
+export * from './TagInput';


### PR DESCRIPTION
## Summary
- add new TagInput molecule with hooks for adding/removing tags
- document TagInput usage in Storybook and add stories
- include unit tests for TagInput

## Testing
- `pnpm test:frontend` *(fails: pnpm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687936819260832b890d4b70d2d5e8d8