### PR TITLE
Add FilterTagList molecule

### DIFF
--- a/frontend/src/molecules/FilterTagList/FilterTagList.docs.mdx
+++ b/frontend/src/molecules/FilterTagList/FilterTagList.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { FilterTagList } from './FilterTagList';
+
+<Meta title="Molecules/FilterTagList" of={FilterTagList} />
+
+# FilterTagList
+
+Shows the list of active filters as removable tags. Each tag can be removed individually or all at once.
+
+<Canvas>
+  <Story name="Examples">
+    <FilterTagList
+      filters={["Categoría: Camisas", "Talla: M", "Marca: ACME"]}
+      showClearAll
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={FilterTagList} />

--- a/frontend/src/molecules/FilterTagList/FilterTagList.stories.tsx
+++ b/frontend/src/molecules/FilterTagList/FilterTagList.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FilterTagList, FilterTagListProps } from './FilterTagList';
+import { iconMap, type IconName } from '@/atoms/Icon';
+
+interface FilterTagListStoryProps extends FilterTagListProps {
+  icon?: IconName;
+}
+
+const iconOptions = Object.keys(iconMap) as IconName[];
+
+const meta: Meta<FilterTagListStoryProps> = {
+  title: 'Molecules/FilterTagList',
+  component: FilterTagList,
+  tags: ['autodocs'],
+  argTypes: {
+    filters: { control: 'object' },
+    showClearAll: { control: 'boolean' },
+    tagVariant: { control: 'select', options: ['outline', 'solid'] },
+    tagColor: {
+      control: 'select',
+      options: [
+        'primary',
+        'secondary',
+        'tertiary',
+        'quaternary',
+        'success',
+        'destructive',
+      ],
+    },
+    icon: { control: 'select', options: [undefined, ...iconOptions] },
+    onRemove: { action: 'removed', table: { category: 'Events' } },
+    onClearAll: { action: 'cleared', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    filters: ['Categoría: Camisas', 'Talla: M', 'Marca: ACME'],
+    showClearAll: true,
+    tagVariant: 'outline',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    filters: ['Color: Azul', 'Talla: L'],
+    showClearAll: true,
+    icon: 'Filter',
+  },
+};
+
+export const Solid: Story = {
+  args: {
+    filters: ['Categoria: Pantalones', 'Marca: XYZ'],
+    tagVariant: 'solid',
+    tagColor: 'secondary',
+  },
+};

--- a/frontend/src/molecules/FilterTagList/FilterTagList.test.tsx
+++ b/frontend/src/molecules/FilterTagList/FilterTagList.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FilterTagList } from './FilterTagList';
+
+describe('FilterTagList', () => {
+  it('renders all filters as tags', () => {
+    render(<FilterTagList filters={['A', 'B']} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('calls onRemove when a tag is closed', () => {
+    const handleRemove = vi.fn();
+    render(<FilterTagList filters={['A']} onRemove={handleRemove} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleRemove).toHaveBeenCalledWith('A');
+  });
+
+  it('calls onClearAll when clicking clear button', () => {
+    const handleClear = vi.fn();
+    render(
+      <FilterTagList filters={['A']} showClearAll onClearAll={handleClear} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Quitar filtros' }));
+    expect(handleClear).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/molecules/FilterTagList/FilterTagList.tsx
+++ b/frontend/src/molecules/FilterTagList/FilterTagList.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Tag, tagVariants } from '@/atoms/Tag';
+import { Button } from '@/atoms/Button';
+import { Icon, type IconName } from '@/atoms/Icon';
+
+export interface FilterTagListProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Array of filter labels */
+  filters: string[];
+  /** Show a button to clear all filters */
+  showClearAll?: boolean;
+  /** Variant style for the tags */
+  tagVariant?: VariantProps<typeof tagVariants>['variant'];
+  /** Color style for the tags */
+  tagColor?: VariantProps<typeof tagVariants>['color'];
+  /** Optional icon to display before each filter label */
+  icon?: IconName;
+  /** Fired when a single filter is removed */
+  onRemove?: (filter: string) => void;
+  /** Fired when all filters are cleared */
+  onClearAll?: () => void;
+}
+
+export const FilterTagList = React.forwardRef<HTMLDivElement, FilterTagListProps>(
+  (
+    {
+      filters,
+      showClearAll = false,
+      tagVariant = 'outline',
+      tagColor = 'primary',
+      icon,
+      onRemove,
+      onClearAll,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn('flex flex-wrap items-center gap-2', className)}
+        {...props}
+      >
+        {filters.map((filter) => (
+          <Tag
+            key={filter}
+            variant={tagVariant}
+            color={tagColor}
+            closable
+            onRemove={() => onRemove?.(filter)}
+          >
+            {icon && (
+              <Icon name={icon} size="sm" className="mr-1" aria-hidden="true" />
+            )}
+            {filter}
+          </Tag>
+        ))}
+        {showClearAll && filters.length > 0 && (
+          <Button
+            variant="ghost"
+            intent="primary"
+            size="sm"
+            onClick={onClearAll}
+            className="whitespace-nowrap"
+          >
+            Quitar filtros
+          </Button>
+        )}
+      </div>
+    );
+  },
+);
+FilterTagList.displayName = 'FilterTagList';
+
+export default FilterTagList;

--- a/frontend/src/molecules/FilterTagList/index.ts
+++ b/frontend/src/molecules/FilterTagList/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterTagList';


### PR DESCRIPTION
## Summary
- create `FilterTagList` molecule for showing active filters
- add Storybook stories and docs
- provide unit tests

## Testing
- `pnpm test:frontend` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879368b41f8832ba2f850787d2afbe7