### PR TITLE
Add OrderItem molecule

### DIFF
--- a/frontend/src/molecules/OrderItem/OrderItem.docs.mdx
+++ b/frontend/src/molecules/OrderItem/OrderItem.docs.mdx
@@ -1,0 +1,18 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { OrderItem } from './OrderItem';
+
+<Meta title="Molecules/OrderItem" of={OrderItem} />
+
+# OrderItem
+
+The `OrderItem` component displays a brief summary of an order.
+
+<Canvas>
+  <Story name="Example">
+    <div className="max-w-sm">
+      <OrderItem orderId="#1001" date="12/07/2025" total="$250.00" status="Pendiente" showIcon />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={OrderItem} />

--- a/frontend/src/molecules/OrderItem/OrderItem.stories.tsx
+++ b/frontend/src/molecules/OrderItem/OrderItem.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OrderItem, type OrderItemProps, type OrderStatus } from './OrderItem';
+
+const statusOptions: OrderStatus[] = ['Entregado', 'Pendiente', 'Cancelado', 'En ruta'];
+
+const meta: Meta<OrderItemProps> = {
+  title: 'Molecules/OrderItem',
+  component: OrderItem,
+  tags: ['autodocs'],
+  argTypes: {
+    orderId: { control: 'text' },
+    date: { control: 'text' },
+    total: { control: 'text' },
+    status: { control: 'select', options: statusOptions },
+    showIcon: { control: 'boolean' },
+    onSelect: { action: 'orderSelected' },
+    onActionClick: { action: 'actionClicked' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    orderId: '#1001',
+    date: '12/07/2025',
+    total: '$250.00',
+    status: 'Pendiente',
+    showIcon: true,
+  },
+};
+
+export const WithoutIcon: Story = {
+  args: {
+    orderId: '#1002',
+    date: '15/07/2025',
+    total: '$120.00',
+    status: 'Entregado',
+    showIcon: false,
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    orderId: '#1003',
+    date: '18/07/2025',
+    total: '$90.00',
+    status: 'En ruta',
+    showIcon: true,
+    onActionClick: () => {},
+  },
+};

--- a/frontend/src/molecules/OrderItem/OrderItem.test.tsx
+++ b/frontend/src/molecules/OrderItem/OrderItem.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { OrderItem } from './OrderItem';
+
+describe('OrderItem', () => {
+  it('renders order details', () => {
+    render(
+      <OrderItem orderId="#1" date="01/01/2024" total="$10" status="Pendiente" />,
+    );
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(screen.getByText('01/01/2024')).toBeInTheDocument();
+    expect(screen.getByText('$10')).toBeInTheDocument();
+    expect(screen.getByText('Pendiente')).toBeInTheDocument();
+  });
+
+  it('shows icon when enabled', () => {
+    render(
+      <OrderItem
+        orderId="#2"
+        date="01/01/2024"
+        total="$20"
+        status="Entregado"
+        showIcon
+      />,
+    );
+    const icon = screen.getByTestId('order-icon');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('handles select action', () => {
+    const onSelect = vi.fn();
+    render(
+      <OrderItem
+        orderId="#3"
+        date="01/01/2024"
+        total="$30"
+        status="En ruta"
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls action button handler', () => {
+    const onActionClick = vi.fn();
+    render(
+      <OrderItem
+        orderId="#4"
+        date="01/01/2024"
+        total="$40"
+        status="Cancelado"
+        onActionClick={onActionClick}
+      />,
+    );
+    const button = screen.getByRole('button', { name: /acciones/i });
+    fireEvent.click(button);
+    expect(onActionClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/molecules/OrderItem/OrderItem.tsx
+++ b/frontend/src/molecules/OrderItem/OrderItem.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Card } from '@/atoms/Card';
+import { Text } from '@/atoms/Text';
+import { Badge, type BadgeProps } from '@/atoms/Badge';
+import { Icon } from '@/atoms/Icon';
+import { Button } from '@/atoms/Button/Button';
+import { MoreHorizontal } from 'lucide-react';
+
+export type OrderStatus = 'Entregado' | 'Pendiente' | 'Cancelado' | 'En ruta';
+
+const statusVariantMap: Record<OrderStatus, BadgeProps['variant']> = {
+  Entregado: 'success',
+  Pendiente: 'warning',
+  Cancelado: 'destructive',
+  'En ruta': 'info',
+};
+
+const orderItemVariants = cva('flex items-center gap-3 w-full', {
+  variants: {
+    clickable: {
+      true: 'cursor-pointer hover:bg-muted',
+    },
+  },
+});
+
+export interface OrderItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Identifier of the order */
+  orderId: string;
+  /** Date of the order */
+  date: string;
+  /** Total amount */
+  total: string;
+  /** Status of the order */
+  status: OrderStatus;
+  /** Show the leading icon */
+  showIcon?: boolean;
+  /** Fired when the item is clicked */
+  onSelect?: () => void;
+  /** Fired when the action button is clicked */
+  onActionClick?: () => void;
+}
+
+export const OrderItem = React.forwardRef<HTMLDivElement, OrderItemProps>(
+  (
+    {
+      orderId,
+      date,
+      total,
+      status,
+      showIcon = false,
+      onSelect,
+      onActionClick,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const clickable = !!onSelect;
+    const badgeVariant = statusVariantMap[status];
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!clickable) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onSelect?.();
+      }
+    };
+
+    const handleAction = (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      onActionClick?.();
+    };
+
+    return (
+      <Card
+        ref={ref}
+        role={clickable ? 'button' : undefined}
+        tabIndex={clickable ? 0 : undefined}
+        onClick={onSelect}
+        onKeyDown={handleKeyDown}
+        clickable={clickable}
+        className={cn(orderItemVariants({ clickable }), className)}
+        {...props}
+      >
+        {showIcon && (
+          <Icon
+            name="File"
+            size="lg"
+            aria-hidden="true"
+            data-testid="order-icon"
+            className="text-secondary"
+          />
+        )}
+        <div className="flex flex-1 flex-col gap-1 sm:flex-row sm:items-center">
+          <Text as="span" weight="semibold">
+            {orderId}
+          </Text>
+          <Text as="span" muted>
+            {date}
+          </Text>
+          <Text as="span" className="sm:ml-auto">
+            {total}
+          </Text>
+        </div>
+        <Badge variant={badgeVariant} className="ml-2 whitespace-nowrap">
+          {status}
+        </Badge>
+        {onActionClick && (
+          <Button
+            variant="icon"
+            intent="secondary"
+            size="sm"
+            aria-label="Acciones"
+            onClick={handleAction}
+            className="ml-2"
+          >
+            <MoreHorizontal size={16} />
+          </Button>
+        )}
+      </Card>
+    );
+  },
+);
+OrderItem.displayName = 'OrderItem';
+
+export { orderItemVariants };

--- a/frontend/src/molecules/OrderItem/index.ts
+++ b/frontend/src/molecules/OrderItem/index.ts
@@ -1,0 +1,1 @@
+export * from './OrderItem';


### PR DESCRIPTION
## Summary
- implement new `OrderItem` molecule with icon, date, total and status
- document OrderItem in Storybook
- add OrderItem stories
- test OrderItem behaviour

## Testing
- `pnpm test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_687936b34fd4832b941d9dc79af4300b