### PR TITLE
Add EditableField molecule

### DIFF
--- a/frontend/src/molecules/EditableField/EditableField.docs.mdx
+++ b/frontend/src/molecules/EditableField/EditableField.docs.mdx
@@ -1,0 +1,19 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { EditableField } from './EditableField';
+
+<Meta title="Molecules/EditableField" of={EditableField} />
+
+# EditableField
+
+The `EditableField` component lets users edit text directly in place. Click the pencil icon to switch to edit mode, then confirm or cancel the changes.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="space-y-2">
+      <EditableField initialValue="Producto 1" />
+      <EditableField initialValue="En edición" editable />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={EditableField} />

--- a/frontend/src/molecules/EditableField/EditableField.stories.tsx
+++ b/frontend/src/molecules/EditableField/EditableField.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EditableField, EditableFieldProps } from './EditableField';
+
+const meta: Meta<EditableFieldProps> = {
+  title: 'Molecules/EditableField',
+  component: EditableField,
+  tags: ['autodocs'],
+  argTypes: {
+    initialValue: { control: 'text', name: 'valorInicial' },
+    editable: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    size: { control: 'select', options: ['sm', 'md', 'lg'], name: 'tamaño' },
+    headingLevel: { control: 'number', options: [undefined,1,2,3,4,5,6], name: 'headingLevel' },
+    onSave: { action: 'save' },
+    onCancel: { action: 'cancel' },
+    onEditStart: { action: 'editStart' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    initialValue: 'Nombre de producto',
+    placeholder: 'Escriba aquí...',
+  },
+};
+
+export const Editing: Story = {
+  args: {
+    initialValue: 'Nombre de producto',
+    editable: true,
+  },
+};

--- a/frontend/src/molecules/EditableField/EditableField.test.tsx
+++ b/frontend/src/molecules/EditableField/EditableField.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { EditableField } from './EditableField';
+
+describe('EditableField', () => {
+  it('renders initial text', () => {
+    render(<EditableField initialValue="Hello" />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('enters edit mode and saves new value', () => {
+    const handleSave = vi.fn();
+    render(<EditableField initialValue="Hello" onSave={handleSave} />);
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'World' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(screen.getByText('World')).toBeInTheDocument();
+    expect(handleSave).toHaveBeenCalledWith('World');
+  });
+
+  it('cancels edits', () => {
+    const handleCancel = vi.fn();
+    render(<EditableField initialValue="Hello" onCancel={handleCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'World' } });
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(handleCancel).toHaveBeenCalled();
+  });
+
+  it('respects editable prop', () => {
+    render(<EditableField initialValue="Hi" editable />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/molecules/EditableField/EditableField.tsx
+++ b/frontend/src/molecules/EditableField/EditableField.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { Text } from '@/atoms/Text';
+import { Heading } from '@/atoms/Heading';
+import { Input } from '@/atoms/Input';
+import { Icon } from '@/atoms/Icon';
+
+export interface EditableFieldProps {
+  /** Initial value shown when not editing */
+  initialValue?: string;
+  /** Placeholder for the input when empty */
+  placeholder?: string;
+  /** Size of the text and input */
+  size?: 'sm' | 'md' | 'lg';
+  /** Force editing state externally */
+  editable?: boolean;
+  /** Use heading instead of text. Provide heading level */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  /** Callback when saving the new value */
+  onSave?: (value: string) => void;
+  /** Callback when cancelling editing */
+  onCancel?: () => void;
+  /** Callback when editing starts */
+  onEditStart?: () => void;
+  className?: string;
+}
+
+export const EditableField = React.forwardRef<HTMLDivElement, EditableFieldProps>(
+  (
+    {
+      initialValue = '',
+      placeholder = '',
+      size = 'md',
+      editable,
+      headingLevel,
+      onSave,
+      onCancel,
+      onEditStart,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const [value, setValue] = React.useState(initialValue);
+    const [editValue, setEditValue] = React.useState(initialValue);
+    const [internalEditing, setInternalEditing] = React.useState(false);
+
+    const isEditing = editable !== undefined ? editable : internalEditing;
+
+    const startEdit = () => {
+      setEditValue(value);
+      if (editable === undefined) {
+        setInternalEditing(true);
+      }
+      onEditStart?.();
+    };
+
+    const handleSave = () => {
+      setValue(editValue);
+      if (editable === undefined) {
+        setInternalEditing(false);
+      }
+      onSave?.(editValue);
+    };
+
+    const handleCancel = () => {
+      setEditValue(value);
+      if (editable === undefined) {
+        setInternalEditing(false);
+      }
+      onCancel?.();
+    };
+
+    const DisplayComponent = headingLevel ? Heading : Text;
+
+    return (
+      <div className={cn('inline-flex items-center gap-2', className)} ref={ref} {...props}>
+        {isEditing ? (
+          <>
+            <Input
+              size={size}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              placeholder={placeholder}
+              className="w-40"
+            />
+            <button type="button" onClick={handleSave} aria-label="Save" className="text-success hover:text-success/80">
+              <Icon name="Check" size="sm" />
+            </button>
+            <button type="button" onClick={handleCancel} aria-label="Cancel" className="text-destructive hover:text-destructive/80">
+              <Icon name="X" size="sm" />
+            </button>
+          </>
+        ) : (
+          <>
+            <DisplayComponent
+              as={headingLevel ? undefined : 'span'}
+              level={headingLevel as any}
+              size={size as any}
+              className="hover:underline decoration-dotted underline-offset-2"
+            >
+              {value || placeholder}
+            </DisplayComponent>
+            <button type="button" onClick={startEdit} aria-label="Edit" className="text-muted-foreground hover:text-foreground">
+              <Icon name="Edit" size="sm" />
+            </button>
+          </>
+        )}
+      </div>
+    );
+  },
+);
+EditableField.displayName = 'EditableField';

--- a/frontend/src/molecules/EditableField/index.ts
+++ b/frontend/src/molecules/EditableField/index.ts
@@ -1,0 +1,1 @@
+export * from './EditableField';


### PR DESCRIPTION
## Summary
- add EditableField molecule
- document and demo component in Storybook
- test editing, saving and canceling

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687936bca214832b94a4eca5618d68a3