### PR TITLE
Add ActionMenu molecule

### DIFF
--- a/frontend/src/molecules/ActionMenu/ActionMenu.docs.mdx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.docs.mdx
@@ -1,0 +1,21 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { ActionMenu } from './ActionMenu';
+import { MoreHorizontal } from 'lucide-react';
+
+<Meta title="Molecules/ActionMenu" of={ActionMenu} />
+
+# ActionMenu
+
+The `ActionMenu` component displays a dropdown menu with quick actions. It is typically triggered by an icon-only button.
+
+<Canvas>
+  <Story name="Example">
+    <ActionMenu
+      options={[{ label: 'Edit', iconName: 'Edit' }, { label: 'Delete', iconName: 'Trash2' }]}
+    >
+      <MoreHorizontal />
+    </ActionMenu>
+  </Story>
+</Canvas>
+
+<ArgsTable of={ActionMenu} />

--- a/frontend/src/molecules/ActionMenu/ActionMenu.stories.tsx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActionMenu, type ActionMenuProps } from './ActionMenu';
+import { MoreHorizontal } from 'lucide-react';
+import { iconMap, type IconName } from '@/atoms/Icon';
+
+interface Props extends ActionMenuProps {
+  iconName: IconName;
+}
+
+const iconOptions = Object.keys(iconMap) as IconName[];
+
+const meta: Meta<Props> = {
+  title: 'Molecules/ActionMenu',
+  component: ActionMenu,
+  tags: ['autodocs'],
+  argTypes: {
+    options: { control: 'object' },
+    position: { control: 'select', options: ['bottom-left', 'bottom-right'] },
+    disabled: { control: 'boolean' },
+    showIcons: { control: 'boolean' },
+    onOptionSelect: { action: 'option selected' },
+    onOpen: { action: 'opened' },
+    onClose: { action: 'closed' },
+    iconName: { control: 'select', options: iconOptions },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const baseOptions = [
+  { label: 'Edit', iconName: 'Edit' },
+  { label: 'Delete', iconName: 'Trash2' },
+  { label: 'Duplicate', iconName: 'Copy' },
+];
+
+export const Default: Story = {
+  args: {
+    options: baseOptions,
+    showIcons: true,
+    iconName: 'MoreHorizontal',
+  },
+  render: ({ iconName, ...args }) => (
+    <ActionMenu {...args}>
+      {iconMap[iconName]({ size: 16 })}
+    </ActionMenu>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    options: baseOptions,
+    disabled: true,
+    iconName: 'MoreHorizontal',
+  },
+  render: ({ iconName, ...args }) => (
+    <ActionMenu {...args}>
+      {iconMap[iconName]({ size: 16 })}
+    </ActionMenu>
+  ),
+};

--- a/frontend/src/molecules/ActionMenu/ActionMenu.test.tsx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ActionMenu } from './ActionMenu';
+import { MoreHorizontal } from 'lucide-react';
+
+const options = [
+  { label: 'Edit', iconName: 'Edit' },
+  { label: 'Delete', iconName: 'Trash2' },
+];
+
+describe('ActionMenu', () => {
+  it('opens and closes menu', () => {
+    render(
+      <ActionMenu options={options}>
+        <MoreHorizontal />
+      </ActionMenu>
+    );
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('calls onOptionSelect', () => {
+    const onSelect = vi.fn();
+    render(
+      <ActionMenu options={options} onOptionSelect={onSelect}>
+        <MoreHorizontal />
+      </ActionMenu>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onSelect).toHaveBeenCalledWith(options[1], 1);
+  });
+
+  it('does not open when disabled', () => {
+    render(
+      <ActionMenu options={options} disabled>
+        <MoreHorizontal />
+      </ActionMenu>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/molecules/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Button } from '@/atoms/Button/Button';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { Card } from '@/atoms/Card';
+import { Text } from '@/atoms/Text';
+
+const menuVariants = cva(
+  'z-50 absolute min-w-[8rem] rounded-md shadow-md',
+  {
+    variants: {
+      position: {
+        'bottom-left': 'origin-top-left',
+        'bottom-right': 'origin-top-right',
+      },
+    },
+    defaultVariants: {
+      position: 'bottom-left',
+    },
+  },
+);
+
+export interface ActionMenuOption {
+  /** Text label for the option */
+  label: string;
+  /** Optional icon for the option */
+  iconName?: IconName;
+  /** Value passed back on selection */
+  value?: string;
+}
+
+export interface ActionMenuProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onSelect'>,
+    VariantProps<typeof menuVariants> {
+  /** Options to display */
+  options: ActionMenuOption[];
+  /** Called when an option is selected */
+  onOptionSelect?: (option: ActionMenuOption, index: number) => void;
+  /** Called when menu is opened */
+  onOpen?: () => void;
+  /** Called when menu is closed */
+  onClose?: () => void;
+  /** Disable trigger button */
+  disabled?: boolean;
+  /** Show icons next to options */
+  showIcons?: boolean;
+}
+
+export const ActionMenu = React.forwardRef<HTMLButtonElement, ActionMenuProps>(
+  (
+    {
+      options,
+      onOptionSelect,
+      onOpen,
+      onClose,
+      position,
+      className,
+      disabled,
+      showIcons = true,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const [open, setOpen] = React.useState(false);
+    const triggerRef = React.useRef<HTMLButtonElement>(null);
+    const menuRef = React.useRef<HTMLDivElement>(null);
+    const id = React.useId();
+
+    const handleOpen = React.useCallback(() => {
+      if (disabled) return;
+      setOpen(true);
+      onOpen?.();
+    }, [disabled, onOpen]);
+
+    const handleClose = React.useCallback(() => {
+      setOpen(false);
+      onClose?.();
+    }, [onClose]);
+
+    const handleClickOutside = React.useCallback(
+      (e: MouseEvent) => {
+        if (
+          menuRef.current &&
+          !menuRef.current.contains(e.target as Node) &&
+          !triggerRef.current?.contains(e.target as Node)
+        ) {
+          handleClose();
+        }
+      },
+      [handleClose],
+    );
+
+    React.useEffect(() => {
+      if (!open) return;
+      document.addEventListener('mousedown', handleClickOutside);
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') handleClose();
+      };
+      document.addEventListener('keydown', handleKey);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('keydown', handleKey);
+      };
+    }, [open, handleClickOutside, handleClose]);
+
+    const [style, setStyle] = React.useState<React.CSSProperties>();
+    const updatePosition = React.useCallback(() => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const top = rect.bottom + 4;
+      const left =
+        position === 'bottom-right' ? rect.right : rect.left;
+      const transform =
+        position === 'bottom-right' ? 'translateX(-100%)' : undefined;
+      setStyle({ top, left, transform });
+    }, [position]);
+
+    React.useEffect(() => {
+      if (!open) return;
+      updatePosition();
+      window.addEventListener('scroll', updatePosition, true);
+      window.addEventListener('resize', updatePosition);
+      return () => {
+        window.removeEventListener('scroll', updatePosition, true);
+        window.removeEventListener('resize', updatePosition);
+      };
+    }, [open, updatePosition]);
+
+    const menu = (
+      <Card
+        ref={menuRef}
+        variant="glass"
+        style={style}
+        className={cn(menuVariants({ position, className }), 'bg-white')}
+        role="menu"
+        aria-labelledby={id}
+      >
+        <div className="py-1">
+          {options.map((option, idx) => (
+            <button
+              key={idx}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onOptionSelect?.(option, idx);
+                handleClose();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted focus:bg-muted focus:outline-none"
+            >
+              {showIcons && option.iconName && (
+                <Icon name={option.iconName} size="sm" aria-hidden="true" />
+              )}
+              <Text as="span" size="sm">
+                {option.label}
+              </Text>
+            </button>
+          ))}
+        </div>
+      </Card>
+    );
+
+    return (
+      <>
+        <Button
+          variant="icon"
+          size="sm"
+          ref={triggerRef}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={id}
+          onClick={open ? handleClose : handleOpen}
+          disabled={disabled}
+          {...props}
+        >
+          {children}
+        </Button>
+        {open && createPortal(menu, document.body)}
+      </>
+    );
+  },
+);
+ActionMenu.displayName = 'ActionMenu';
+
+export { menuVariants };

--- a/frontend/src/molecules/ActionMenu/index.ts
+++ b/frontend/src/molecules/ActionMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './ActionMenu';


### PR DESCRIPTION
## Summary
- add ActionMenu molecule with dropdown actions
- document usage in Storybook
- provide stories and unit tests

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687936c74558832b9f0643d2e19d0281