### PR TITLE
Add StepIndicator molecule

### DIFF
--- a/frontend/src/molecules/StepIndicator/StepIndicator.docs.mdx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.docs.mdx
@@ -1,0 +1,21 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { StepIndicator } from './StepIndicator';
+
+<Meta title="Molecules/StepIndicator" of={StepIndicator} />
+
+# StepIndicator
+
+The `StepIndicator` component displays progress through a multi-step process. Each step shows a numbered circle or a checkmark when completed.
+
+<Canvas>
+  <Story name="Example">
+    <StepIndicator
+      totalSteps={4}
+      currentStep={2}
+      labels={["Detalles", "Imágenes", "Precios", "Confirmación"]}
+      clickable
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={StepIndicator} />

--- a/frontend/src/molecules/StepIndicator/StepIndicator.stories.tsx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StepIndicator, StepIndicatorProps } from './StepIndicator';
+
+const meta: Meta<StepIndicatorProps> = {
+  title: 'Molecules/StepIndicator',
+  component: StepIndicator,
+  tags: ['autodocs'],
+  argTypes: {
+    totalSteps: { control: { type: 'number', min: 1 } },
+    currentStep: { control: { type: 'number', min: 1 } },
+    labels: { control: 'object' },
+    clickable: { control: 'boolean' },
+    onStepClick: { action: 'stepClicked' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    totalSteps: 4,
+    currentStep: 2,
+    labels: ['Detalles', 'Imágenes', 'Precios', 'Confirmación'],
+    clickable: true,
+  },
+};

--- a/frontend/src/molecules/StepIndicator/StepIndicator.test.tsx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { StepIndicator } from './StepIndicator';
+
+describe('StepIndicator', () => {
+  it('renders the correct number of steps', () => {
+    render(
+      <StepIndicator totalSteps={3} currentStep={2} labels={['A', 'B', 'C']} />,
+    );
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('shows check icon for completed steps', () => {
+    render(<StepIndicator totalSteps={2} currentStep={2} />);
+    const first = screen.getAllByRole('button')[0];
+    expect(first.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onStepClick when clicking previous step', () => {
+    const handle = vi.fn();
+    render(
+      <StepIndicator totalSteps={3} currentStep={2} clickable onStepClick={handle} />,
+    );
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(handle).toHaveBeenCalledWith(1);
+  });
+
+  it('ignores click on current step', () => {
+    const handle = vi.fn();
+    render(
+      <StepIndicator totalSteps={3} currentStep={2} clickable onStepClick={handle} />,
+    );
+    fireEvent.click(screen.getAllByRole('button')[1]);
+    expect(handle).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/molecules/StepIndicator/StepIndicator.tsx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+import { Icon } from '@/atoms/Icon';
+import { Text } from '@/atoms/Text';
+
+const circleVariants = cva(
+  'flex items-center justify-center w-8 h-8 rounded-full border text-sm font-medium transition-colors',
+  {
+    variants: {
+      state: {
+        completed: 'bg-success text-success-foreground border-success',
+        current: 'bg-primary text-primary-foreground border-primary',
+        pending: 'text-muted-foreground border-border',
+      },
+      clickable: {
+        true: 'cursor-pointer hover:bg-muted',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      state: 'pending',
+      clickable: false,
+    },
+  },
+);
+
+export interface StepIndicatorProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof circleVariants> {
+  /** Total number of steps */
+  totalSteps: number;
+  /** Current active step (1-indexed) */
+  currentStep: number;
+  /** Labels for each step */
+  labels?: string[];
+  /** Allow clicking on completed steps */
+  clickable?: boolean;
+  /** Callback when a step is clicked */
+  onStepClick?: (step: number) => void;
+}
+
+export const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
+  (
+    {
+      totalSteps,
+      currentStep,
+      labels = [],
+      clickable = false,
+      onStepClick,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const steps = Array.from({ length: totalSteps }, (_, i) => i + 1);
+    const finalLabels =
+      labels.length === totalSteps ? labels : steps.map((n) => `Paso ${n}`);
+
+    return (
+      <div ref={ref} className={cn('flex items-center w-full', className)} {...props}>
+        {steps.map((step, index) => {
+          const state =
+            step < currentStep ? 'completed' : step === currentStep ? 'current' : 'pending';
+          const isClickable = clickable && step < currentStep;
+          const handleClick = () => {
+            if (isClickable) onStepClick?.(step);
+          };
+          return (
+            <React.Fragment key={step}>
+              <div className="flex flex-col items-center">
+                <button
+                  type="button"
+                  className={circleVariants({ state, clickable: isClickable })}
+                  onClick={handleClick}
+                  disabled={!isClickable}
+                >
+                  {state === 'completed' ? (
+                    <Icon name="Check" size="sm" aria-hidden="true" />
+                  ) : (
+                    step
+                  )}
+                </button>
+                <Text as="span" size="sm" className="mt-1 text-center">
+                  {finalLabels[index]}
+                </Text>
+              </div>
+              {index < steps.length - 1 && (
+                <div
+                  className={cn(
+                    'mx-2 flex-1 border-t',
+                    step < currentStep ? 'border-success' : 'border-border',
+                  )}
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+    );
+  },
+);
+StepIndicator.displayName = 'StepIndicator';
+
+export { circleVariants as stepIndicatorCircleVariants };

--- a/frontend/src/molecules/StepIndicator/index.ts
+++ b/frontend/src/molecules/StepIndicator/index.ts
@@ -1,0 +1,1 @@
+export * from './StepIndicator';


### PR DESCRIPTION
## Summary
- create StepIndicator molecule to show multi-step progress
- add Storybook story and docs
- add unit tests

## Testing
- `pnpm --filter ./frontend exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687936da3da4832bbc299d18dd48698d