### PR TITLE
Add TimelineItem molecule

### DIFF
--- a/frontend/src/molecules/TimelineItem/TimelineItem.docs.mdx
+++ b/frontend/src/molecules/TimelineItem/TimelineItem.docs.mdx
@@ -1,0 +1,29 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { TimelineItem } from './TimelineItem';
+
+<Meta title="Molecules/TimelineItem" of={TimelineItem} />
+
+# TimelineItem
+
+The `TimelineItem` component represents a single entry inside a vertical timeline. It displays an icon, a short title, optional description and a timestamp so users can follow the sequence of events.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="max-w-sm space-y-4">
+      <TimelineItem
+        iconName="Clock"
+        title="Pedido entregado"
+        description="El pedido #1042 fue entregado al cliente"
+        date="05/07/2025 14:32"
+      />
+      <TimelineItem
+        iconName="User"
+        title="Cliente registrado"
+        color="success"
+        date="01/07/2025 10:00"
+      />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={TimelineItem} />

--- a/frontend/src/molecules/TimelineItem/TimelineItem.stories.tsx
+++ b/frontend/src/molecules/TimelineItem/TimelineItem.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TimelineItem, TimelineItemProps } from './TimelineItem';
+import { iconMap, type IconName } from '@/atoms/Icon';
+
+interface TimelineStoryProps extends TimelineItemProps {
+  iconName: IconName;
+}
+
+const iconOptions = Object.keys(iconMap) as IconName[];
+
+const meta: Meta<TimelineStoryProps> = {
+  title: 'Molecules/TimelineItem',
+  component: TimelineItem,
+  tags: ['autodocs'],
+  argTypes: {
+    iconName: { control: 'select', options: iconOptions },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+    },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    date: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    iconName: 'Clock',
+    title: 'Pedido entregado',
+    description: 'El pedido #1042 fue entregado al cliente',
+    date: '05/07/2025 14:32',
+    color: 'primary',
+  },
+};

--- a/frontend/src/molecules/TimelineItem/TimelineItem.test.tsx
+++ b/frontend/src/molecules/TimelineItem/TimelineItem.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { TimelineItem } from './TimelineItem';
+
+describe('TimelineItem', () => {
+  it('renders title and description', () => {
+    render(
+      <TimelineItem
+        iconName="Clock"
+        title="Evento"
+        description="Detalle del evento"
+      />,
+    );
+    expect(screen.getByText('Evento')).toBeInTheDocument();
+    expect(screen.getByText('Detalle del evento')).toBeInTheDocument();
+  });
+
+  it('renders date when provided', () => {
+    render(<TimelineItem iconName="Clock" title="Evento" date="01/01/2025" />);
+    expect(screen.getByText('01/01/2025')).toBeInTheDocument();
+  });
+
+  it('applies color variant', () => {
+    render(<TimelineItem iconName="Clock" title="Evento" color="success" />);
+    const indicator = screen.getByTestId('indicator');
+    expect(indicator.className).toContain('border-success');
+  });
+
+  it('merges additional class names', () => {
+    render(
+      <TimelineItem
+        iconName="Clock"
+        title="Evento"
+        className="mb-4"
+        data-testid="item"
+      />,
+    );
+    expect(screen.getByTestId('item').className).toContain('mb-4');
+  });
+});

--- a/frontend/src/molecules/TimelineItem/TimelineItem.tsx
+++ b/frontend/src/molecules/TimelineItem/TimelineItem.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { Heading } from '@/atoms/Heading';
+import { Text } from '@/atoms/Text';
+
+const indicatorVariants = cva(
+  'absolute left-0 top-0 flex items-center justify-center w-6 h-6 rounded-full border-2 bg-background',
+  {
+    variants: {
+      color: {
+        primary: 'border-primary text-primary',
+        secondary: 'border-secondary text-secondary',
+        tertiary: 'border-tertiary text-tertiary',
+        quaternary: 'border-quaternary text-quaternary',
+        success: 'border-success text-success',
+        destructive: 'border-destructive text-destructive',
+      },
+    },
+    defaultVariants: { color: 'primary' },
+  },
+);
+
+export interface TimelineItemProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof indicatorVariants> {
+  /** Short title describing the event */
+  title: string;
+  /** Additional detail about the event */
+  description?: string;
+  /** Date or time string associated with the event */
+  date?: string;
+  /** Icon representing the event */
+  iconName: IconName;
+}
+
+export const TimelineItem = React.forwardRef<HTMLDivElement, TimelineItemProps>(
+  ({ title, description, date, iconName, color, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'relative flex gap-4 pl-9 pb-6 last:pb-0 after:absolute after:left-3 after:top-6 after:bottom-0 after:w-px after:bg-border after:content-[""] last:after:hidden',
+          className,
+        )}
+        {...props}
+      >
+        <span data-testid="indicator" className={indicatorVariants({ color })}>
+          <Icon name={iconName} size="sm" aria-hidden="true" />
+        </span>
+        <div className="flex-1 space-y-1">
+          <div className="flex items-baseline justify-between">
+            <Heading level={6} as="h3" className="font-semibold">
+              {title}
+            </Heading>
+            {date && (
+              <Text as="span" size="sm" muted className="ml-2 whitespace-nowrap">
+                {date}
+              </Text>
+            )}
+          </div>
+          {description && (
+            <Text as="p" size="sm">
+              {description}
+            </Text>
+          )}
+        </div>
+      </div>
+    );
+  },
+);
+TimelineItem.displayName = 'TimelineItem';
+
+export { indicatorVariants as timelineIndicatorVariants };

--- a/frontend/src/molecules/TimelineItem/index.ts
+++ b/frontend/src/molecules/TimelineItem/index.ts
@@ -1,0 +1,1 @@
+export * from './TimelineItem';


### PR DESCRIPTION
## Summary
- add TimelineItem molecule with customizable color and icon
- document TimelineItem usage in Storybook
- provide Storybook stories and unit tests

## Testing
- `pnpm test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_687936f71bb4832ba41074cd1bc9de79