### PR TITLE
Add ImageUploader molecule

### DIFF
--- a/frontend/src/molecules/ImageUploader/ImageUploader.docs.mdx
+++ b/frontend/src/molecules/ImageUploader/ImageUploader.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { ImageUploader } from './ImageUploader';
+
+<Meta title="Molecules/ImageUploader" of={ImageUploader} />
+
+# ImageUploader
+
+The `ImageUploader` component lets users select image files and immediately preview them. Thumbnails display in a grid with a small remove icon so each image can be deleted before submitting.
+
+<Canvas>
+  <Story name="Examples">
+    <ImageUploader multiple imagenesIniciales={["https://placehold.co/80x80"]} />
+  </Story>
+</Canvas>
+
+<ArgsTable of={ImageUploader} />

--- a/frontend/src/molecules/ImageUploader/ImageUploader.stories.tsx
+++ b/frontend/src/molecules/ImageUploader/ImageUploader.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ImageUploader, type ImageUploaderProps } from './ImageUploader';
+
+const meta: Meta<ImageUploaderProps> = {
+  title: 'Molecules/ImageUploader',
+  component: ImageUploader,
+  tags: ['autodocs'],
+  argTypes: {
+    multiple: { control: 'boolean' },
+    imagenesIniciales: { control: 'text' },
+    labelBoton: { control: 'text' },
+    maxImagenes: { control: 'number' },
+    onUpload: { action: 'onUpload', table: { category: 'Events' } },
+    onRemoveImage: { action: 'onRemoveImage', table: { category: 'Events' } },
+    onMaxExceeded: { action: 'onMaxExceeded', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const parseImages = (val?: string | string[]) => {
+  if (Array.isArray(val)) return val;
+  if (!val) return [];
+  try {
+    const parsed = JSON.parse(val);
+    if (Array.isArray(parsed)) return parsed as string[];
+  } catch {
+    // fallthrough
+  }
+  return val.split(',').map((s) => s.trim()).filter(Boolean);
+};
+
+export const Default: Story = {
+  render: (args) => (
+    <ImageUploader {...args} imagenesIniciales={parseImages(args.imagenesIniciales)} />
+  ),
+  args: {},
+};
+
+export const Multiple: Story = {
+  render: (args) => (
+    <ImageUploader {...args} imagenesIniciales={parseImages(args.imagenesIniciales)} />
+  ),
+  args: { multiple: true },
+};
+
+export const WithInitialImages: Story = {
+  render: (args) => (
+    <ImageUploader {...args} imagenesIniciales={parseImages(args.imagenesIniciales)} />
+  ),
+  args: {
+    imagenesIniciales: [
+      'https://placehold.co/80x80',
+      'https://placehold.co/80x80?text=2',
+    ],
+    multiple: true,
+  },
+};

--- a/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
+++ b/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ImageUploader } from './ImageUploader';
+
+const createFile = (name: string) => new File(['hello'], name, { type: 'image/png' });
+
+describe('ImageUploader', () => {
+  it('renders upload button', () => {
+    render(<ImageUploader />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('shows preview after selecting image', () => {
+    render(<ImageUploader />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('a.png')] } });
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  it('removes image when clicking delete', () => {
+    render(<ImageUploader />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('a.png')] } });
+    fireEvent.click(screen.getByRole('button', { name: /eliminar/i }));
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('respects maxImagenes', () => {
+    render(<ImageUploader multiple maxImagenes={1} />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [createFile('a.png'), createFile('b.png')] } });
+    expect(screen.getAllByRole('img')).toHaveLength(1);
+  });
+});

--- a/frontend/src/molecules/ImageUploader/ImageUploader.tsx
+++ b/frontend/src/molecules/ImageUploader/ImageUploader.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { FileUpload, type FileUploadProps } from '@/atoms/FileUpload';
+import { Icon } from '@/atoms/Icon';
+import { cn } from '@/lib/utils';
+
+export interface ImageUploaderProps
+  extends Omit<FileUploadProps, 'buttonText' | 'multiple' | 'onChange'> {
+  /** Allow selecting multiple images */
+  multiple?: boolean;
+  /** Text for the upload button */
+  labelBoton?: string;
+  /** Maximum number of images allowed */
+  maxImagenes?: number;
+  /** Initial image URLs */
+  imagenesIniciales?: string[];
+  /** Fired when files are selected */
+  onUpload?: (files: File[]) => void;
+  /** Fired when removing image */
+  onRemoveImage?: (index: number) => void;
+  /** Fired when maximum exceeded */
+  onMaxExceeded?: (max: number) => void;
+}
+
+interface PreviewImage {
+  src: string;
+  file?: File;
+}
+
+export const ImageUploader = React.forwardRef<HTMLInputElement, ImageUploaderProps>(
+  (
+    {
+      multiple = false,
+      labelBoton = 'Seleccionar imágenes',
+      maxImagenes,
+      imagenesIniciales = [],
+      onUpload,
+      onRemoveImage,
+      onMaxExceeded,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const [images, setImages] = React.useState<PreviewImage[]>(() =>
+      imagenesIniciales.map((src) => ({ src })),
+    );
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      const files = Array.from(e.target.files ?? []);
+      if (maxImagenes && images.length >= maxImagenes) {
+        onMaxExceeded?.(maxImagenes);
+        return;
+      }
+      let allowedFiles = files;
+      if (maxImagenes && images.length + files.length > maxImagenes) {
+        allowedFiles = files.slice(0, maxImagenes - images.length);
+        onMaxExceeded?.(maxImagenes);
+      }
+      const newImages = allowedFiles.map((file) => ({
+        src: URL.createObjectURL(file),
+        file,
+      }));
+      setImages((prev) => (multiple ? [...prev, ...newImages] : newImages));
+      onUpload?.(allowedFiles);
+    };
+
+    const removeImage = (index: number) => {
+      setImages((prev) => {
+        const removed = prev[index];
+        if (removed?.file) URL.revokeObjectURL(removed.src);
+        const next = prev.filter((_, i) => i !== index);
+        return next;
+      });
+      onRemoveImage?.(index);
+    };
+
+    return (
+      <div className={cn('space-y-2', className)}>
+        <FileUpload
+          ref={ref}
+          multiple={multiple}
+          buttonText={labelBoton}
+          onChange={handleChange}
+          {...props}
+        />
+        {images.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {images.map((img, idx) => (
+              <div
+                key={idx}
+                className="relative h-20 w-20 overflow-hidden rounded-md border border-border shadow-sm"
+              >
+                <img
+                  src={img.src}
+                  alt="preview"
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  aria-label="Eliminar"
+                  onClick={() => removeImage(idx)}
+                  className="absolute right-1 top-1 rounded-full bg-black/60 p-0.5 text-white hover:bg-black/80"
+                >
+                  <Icon name="X" size="sm" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+ImageUploader.displayName = 'ImageUploader';
+
+export { ImageUploader };

--- a/frontend/src/molecules/ImageUploader/index.ts
+++ b/frontend/src/molecules/ImageUploader/index.ts
@@ -1,0 +1,1 @@
+export * from './ImageUploader';


### PR DESCRIPTION
## Summary
- create ImageUploader molecule with preview and remove capability
- add Storybook stories and documentation
- include unit tests

## Testing
- `pnpm test:frontend` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687937173008832ba66fa60c639c82ef