### PR TITLE
Fix Storybook root

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -13,6 +13,7 @@ const config = {
   core: { disableTelemetry: true },
   async viteFinal(config) {
     return mergeConfig(config, {
+      root: path.resolve(__dirname, '..'),
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '../src'),


### PR DESCRIPTION
## Summary
- ensure Storybook's Vite server runs from the `frontend` folder

## Testing
- ❌ `pnpm install` *(fails: network unreachable)*
- ❌ `pnpm run storybook` *(fails: `storybook` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eeded63d4832b9af7cfd480a39a29