### PR TITLE
Fix ActionMenu icon rendering

### DIFF
--- a/frontend/src/molecules/ActionMenu/ActionMenu.docs.mdx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.docs.mdx
@@ -11,10 +11,12 @@ The `ActionMenu` component displays a dropdown menu with quick actions. It is ty
 <Canvas>
   <Story name="Example">
     <ActionMenu
-      options={[{ label: 'Edit', iconName: 'Edit' }, { label: 'Delete', iconName: 'Trash2' }]}
-    >
-      <MoreHorizontal />
-    </ActionMenu>
+      options={[
+        { label: 'Edit', iconName: 'Edit' },
+        { label: 'Delete', iconName: 'Trash2' }
+      ]}
+      iconName="MoreHorizontal"
+    />
   </Story>
 </Canvas>
 

--- a/frontend/src/molecules/ActionMenu/ActionMenu.stories.tsx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.stories.tsx
@@ -1,15 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ActionMenu, type ActionMenuProps } from './ActionMenu';
-import { MoreHorizontal } from 'lucide-react';
 import { iconMap, type IconName } from '@/atoms/Icon';
-
-interface Props extends ActionMenuProps {
-  iconName: IconName;
-}
 
 const iconOptions = Object.keys(iconMap) as IconName[];
 
-const meta: Meta<Props> = {
+const meta: Meta<ActionMenuProps> = {
   title: 'Molecules/ActionMenu',
   component: ActionMenu,
   tags: ['autodocs'],
@@ -40,14 +35,7 @@ export const Default: Story = {
     showIcons: true,
     iconName: 'MoreHorizontal',
   },
-  render: ({ iconName, ...args }) => {
-    const Icon = iconMap[iconName];
-    return (
-      <ActionMenu {...args}>
-        <Icon size={16} />
-      </ActionMenu>
-    );
-  },
+  render: (args) => <ActionMenu {...args} />,
 };
 
 export const Disabled: Story = {
@@ -56,12 +44,5 @@ export const Disabled: Story = {
     disabled: true,
     iconName: 'MoreHorizontal',
   },
-  render: ({ iconName, ...args }) => {
-    const Icon = iconMap[iconName];
-    return (
-      <ActionMenu {...args}>
-        <Icon size={16} />
-      </ActionMenu>
-    );
-  },
+  render: (args) => <ActionMenu {...args} />,
 };

--- a/frontend/src/molecules/ActionMenu/ActionMenu.test.tsx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ActionMenu } from './ActionMenu';
-import { MoreHorizontal } from 'lucide-react';
 
 const options = [
   { label: 'Edit', iconName: 'Edit' },
@@ -10,11 +9,7 @@ const options = [
 
 describe('ActionMenu', () => {
   it('opens and closes menu', () => {
-    render(
-      <ActionMenu options={options}>
-        <MoreHorizontal />
-      </ActionMenu>
-    );
+    render(<ActionMenu options={options} iconName="MoreHorizontal" />);
     const trigger = screen.getByRole('button');
     fireEvent.click(trigger);
     expect(screen.getByRole('menu')).toBeInTheDocument();
@@ -24,22 +19,14 @@ describe('ActionMenu', () => {
 
   it('calls onOptionSelect', () => {
     const onSelect = vi.fn();
-    render(
-      <ActionMenu options={options} onOptionSelect={onSelect}>
-        <MoreHorizontal />
-      </ActionMenu>
-    );
+    render(<ActionMenu options={options} onOptionSelect={onSelect} iconName="MoreHorizontal" />);
     fireEvent.click(screen.getByRole('button'));
     fireEvent.click(screen.getByText('Delete'));
     expect(onSelect).toHaveBeenCalledWith(options[1], 1);
   });
 
   it('does not open when disabled', () => {
-    render(
-      <ActionMenu options={options} disabled>
-        <MoreHorizontal />
-      </ActionMenu>
-    );
+    render(<ActionMenu options={options} disabled iconName="MoreHorizontal" />);
     fireEvent.click(screen.getByRole('button'));
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });

--- a/frontend/src/molecules/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/molecules/ActionMenu/ActionMenu.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 import { Button } from '@/atoms/Button/Button';
-import { Icon, type IconName } from '@/atoms/Icon';
+import { Icon, iconMap, type IconName } from '@/atoms/Icon';
 import { Card } from '@/atoms/Card';
 import { Text } from '@/atoms/Text';
 
@@ -46,6 +46,8 @@ export interface ActionMenuProps
   disabled?: boolean;
   /** Show icons next to options */
   showIcons?: boolean;
+  /** Icon name for the trigger button */
+  iconName?: IconName;
 }
 
 export const ActionMenu = React.forwardRef<HTMLButtonElement, ActionMenuProps>(
@@ -59,7 +61,7 @@ export const ActionMenu = React.forwardRef<HTMLButtonElement, ActionMenuProps>(
       className,
       disabled,
       showIcons = true,
-      children,
+      iconName = 'MoreHorizontal',
       ...props
     },
     ref,
@@ -173,10 +175,9 @@ export const ActionMenu = React.forwardRef<HTMLButtonElement, ActionMenuProps>(
           aria-controls={id}
           onClick={open ? handleClose : handleOpen}
           disabled={disabled}
+          LeftIcon={iconMap[iconName]}
           {...props}
-        >
-          {children}
-        </Button>
+        />
         {open && createPortal(menu, document.body)}
       </>
     );


### PR DESCRIPTION
## Summary
- ensure ActionMenu trigger shows an icon consistently
- update docs and stories to use `iconName` prop
- refresh ActionMenu tests

## Testing
- `pnpm install --frozen-lockfile` *(fails: Cannot use 'in' operator to search for 'errno')*


------
https://chatgpt.com/codex/tasks/task_e_68802ed61568832bb440fc2a3272916b