### PR TITLE
Fix CustomerCard action button and add menu option

### DIFF
--- a/frontend/src/molecules/CustomerCard/CustomerCard.docs.mdx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.docs.mdx
@@ -14,6 +14,12 @@ Opcionalmente se indica el nivel del cliente y un botón de acción.
     <div className="w-72 space-y-2">
       <CustomerCard nombre="María Gómez" infoSecundaria="maria@gmail.com" nivel="VIP" />
       <CustomerCard nombre="Pedro Ruiz" infoSecundaria="pedro@example.com" mostrarAccion />
+      <CustomerCard
+        nombre="Lucía Pérez"
+        infoSecundaria="lucia@example.com"
+        mostrarAccion
+        actionOptions={[{ label: 'Editar', iconName: 'Edit' }]}
+      />
     </div>
   </Story>
 </Canvas>

--- a/frontend/src/molecules/CustomerCard/CustomerCard.stories.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.stories.tsx
@@ -14,6 +14,12 @@ const meta: Meta<CustomerCardProps> = {
       options: [undefined, 'VIP', 'Frecuente', 'Nuevo'],
     },
     mostrarAccion: { control: 'boolean' },
+    accionIntent: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    accionIconName: { control: 'text' },
+    actionOptions: { control: 'object' },
     onSelect: { action: 'selected' },
     onAction: { action: 'actionClicked' },
   },
@@ -38,5 +44,17 @@ export const ConAccion: Story = {
     nombre: 'Pedro Ruiz',
     infoSecundaria: 'pedro@example.com',
     mostrarAccion: true,
+  },
+};
+
+export const ConMenuAccion: Story = {
+  args: {
+    nombre: 'Lucía Pérez',
+    infoSecundaria: 'lucia@example.com',
+    mostrarAccion: true,
+    actionOptions: [
+      { label: 'Editar', iconName: 'Edit' },
+      { label: 'Eliminar', iconName: 'Trash2' },
+    ],
   },
 };

--- a/frontend/src/molecules/CustomerCard/CustomerCard.test.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.test.tsx
@@ -32,4 +32,17 @@ describe('CustomerCard', () => {
     fireEvent.click(btn);
     expect(onAction).toHaveBeenCalledTimes(1);
   });
+
+  it('renders action menu when options provided', () => {
+    render(
+      <CustomerCard
+        nombre="Ana"
+        mostrarAccion
+        actionOptions={[{ label: 'Edit', iconName: 'Edit' }]}
+      />,
+    );
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/molecules/CustomerCard/CustomerCard.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.tsx
@@ -5,7 +5,12 @@ import { Heading } from '@/atoms/Heading';
 import { Text } from '@/atoms/Text';
 import { Badge } from '@/atoms/Badge';
 import { Button } from '@/atoms/Button/Button';
-import { Icon } from '@/atoms/Icon';
+import { Icon, type IconName } from '@/atoms/Icon';
+import {
+  ActionMenu,
+  type ActionMenuOption,
+  type ActionMenuProps,
+} from '@/molecules/ActionMenu';
 import { cn } from '@/lib/utils';
 
 type Nivel = 'VIP' | 'Frecuente' | 'Nuevo';
@@ -27,6 +32,14 @@ export interface CustomerCardProps extends React.HTMLAttributes<HTMLDivElement> 
   nivel?: Nivel;
   /** Show action icon */
   mostrarAccion?: boolean;
+  /** Intent/color for the action button */
+  accionIntent?: React.ComponentProps<typeof Button>['intent'];
+  /** Icon displayed inside the action button */
+  accionIconName?: IconName;
+  /** Options for an optional action menu */
+  actionOptions?: ActionMenuOption[];
+  /** Additional props for the action menu */
+  actionMenuProps?: Omit<ActionMenuProps, 'options' | 'children'>;
   /** Click handler for the card */
   onSelect?: () => void;
   /** Click handler for the action icon */
@@ -41,6 +54,10 @@ export const CustomerCard = React.forwardRef<HTMLDivElement, CustomerCardProps>(
       infoSecundaria,
       nivel,
       mostrarAccion = false,
+      accionIntent = 'primary',
+      accionIconName,
+      actionOptions,
+      actionMenuProps,
       onSelect,
       onAction,
       className,
@@ -84,15 +101,26 @@ export const CustomerCard = React.forwardRef<HTMLDivElement, CustomerCardProps>(
           )}
         </div>
         {mostrarAccion && (
-          <Button
-            variant="icon"
-            size="sm"
-            intent="primary"
-            aria-label="Ver detalles"
-            onClick={handleAction}
-          >
-            <Icon name="ChevronRight" />
-          </Button>
+          actionOptions ? (
+            <ActionMenu
+              options={actionOptions}
+              onOpen={onAction}
+              position="bottom-right"
+              {...actionMenuProps}
+            >
+              <Icon name={accionIconName ?? 'MoreHorizontal'} />
+            </ActionMenu>
+          ) : (
+            <Button
+              variant="icon"
+              size="sm"
+              intent={accionIntent}
+              aria-label="Acciones"
+              onClick={handleAction}
+            >
+              <Icon name={accionIconName ?? 'ChevronRight'} />
+            </Button>
+          )
         )}
       </Card>
     );


### PR DESCRIPTION
## Summary
- make CustomerCard action button customizable
- allow attaching an ActionMenu
- document examples
- update storybook and tests

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802f0df980832bb1f1f2a2787090f2