### PR TITLE
Improve CustomerListItem actions

### DIFF
--- a/frontend/src/molecules/CustomerListItem/CustomerListItem.stories.tsx
+++ b/frontend/src/molecules/CustomerListItem/CustomerListItem.stories.tsx
@@ -13,6 +13,8 @@ const meta: Meta<CustomerListItemProps> = {
     category: { control: 'text' },
     active: { control: 'boolean' },
     showActions: { control: 'boolean' },
+    actionMenuOptions: { control: 'object' },
+    onMenuOptionSelect: { action: 'option select' },
     onClick: { action: 'click' },
     onEdit: { action: 'edit' },
     onContact: { action: 'contact' },
@@ -31,6 +33,8 @@ export const Default: Story = {
     category: 'VIP',
     active: true,
     showActions: true,
+    onEdit: () => {},
+    onContact: () => {},
   },
 };
 
@@ -39,5 +43,17 @@ export const Inactive: Story = {
     customerName: 'Ana Gómez',
     email: 'ana@example.com',
     active: false,
+  },
+};
+
+export const WithMenu: Story = {
+  args: {
+    customerName: 'Carlos',
+    email: 'carlos@example.com',
+    showActions: true,
+    actionMenuOptions: [
+      { label: 'Editar', iconName: 'Edit' },
+      { label: 'Contactar', iconName: 'Mail' },
+    ],
   },
 };

--- a/frontend/src/molecules/CustomerListItem/CustomerListItem.test.tsx
+++ b/frontend/src/molecules/CustomerListItem/CustomerListItem.test.tsx
@@ -33,6 +33,26 @@ describe('CustomerListItem', () => {
     expect(handleEdit).toHaveBeenCalledTimes(1);
   });
 
+  it('opens action menu when options provided', () => {
+    const onSelect = vi.fn();
+    const options = [
+      { label: 'Edit', iconName: 'Edit' },
+      { label: 'Contact', iconName: 'Mail' },
+    ];
+    render(
+      <CustomerListItem
+        customerName="Jane"
+        email="jane@example.com"
+        showActions
+        actionMenuOptions={options}
+        onMenuOptionSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Más acciones' }));
+    fireEvent.click(screen.getByText('Contact'));
+    expect(onSelect).toHaveBeenCalledWith(options[1], 1);
+  });
+
   it('displays inactive badge when active is false', () => {
     render(
       <CustomerListItem customerName="John Doe" email="john@example.com" active={false} />,

--- a/frontend/src/molecules/CustomerListItem/CustomerListItem.tsx
+++ b/frontend/src/molecules/CustomerListItem/CustomerListItem.tsx
@@ -8,6 +8,11 @@ import { Badge } from '@/atoms/Badge';
 import { Tag } from '@/atoms/Tag';
 import { Button } from '@/atoms/Button/Button';
 import { Icon } from '@/atoms/Icon';
+import { Card } from '@/atoms/Card';
+import {
+  ActionMenu,
+  type ActionMenuOption,
+} from '@/molecules/ActionMenu';
 
 const itemVariants = cva(
   'flex items-center w-full rounded-md px-4 py-2 gap-3 text-sm',
@@ -40,6 +45,10 @@ export interface CustomerListItemProps
   active?: boolean;
   /** Show action buttons */
   showActions?: boolean;
+  /** Options for dropdown menu */
+  actionMenuOptions?: ActionMenuOption[];
+  /** Called when a menu option is selected */
+  onMenuOptionSelect?: (option: ActionMenuOption, index: number) => void;
   /** Click handler for the whole row */
   onClick?: () => void;
   /** Edit action */
@@ -58,6 +67,8 @@ export const CustomerListItem = React.forwardRef<HTMLDivElement, CustomerListIte
       category,
       active = true,
       showActions = false,
+      actionMenuOptions,
+      onMenuOptionSelect,
       className,
       clickable,
       onClick,
@@ -68,12 +79,13 @@ export const CustomerListItem = React.forwardRef<HTMLDivElement, CustomerListIte
     ref,
   ) => {
     return (
-      <div
+      <Card
         ref={ref}
         role={onClick ? 'button' : undefined}
         tabIndex={onClick ? 0 : undefined}
         onClick={onClick}
-        className={cn(itemVariants({ clickable: clickable ?? !!onClick }), className)}
+        clickable={clickable ?? !!onClick}
+        className={cn(itemVariants({ clickable: false }), className)}
         {...props}
       >
         <Avatar name={customerName} size="sm" className={!active ? 'opacity-50' : undefined} />
@@ -106,35 +118,47 @@ export const CustomerListItem = React.forwardRef<HTMLDivElement, CustomerListIte
         )}
         {showActions && (
           <div className="ml-2 flex items-center gap-1">
-            {onContact && (
-              <Button
-                variant="icon"
-                intent="secondary"
-                aria-label="Contactar"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onContact();
-                }}
+            {actionMenuOptions?.length ? (
+              <ActionMenu
+                aria-label="Más acciones"
+                options={actionMenuOptions}
+                onOptionSelect={onMenuOptionSelect}
               >
-                <Icon name="Mail" />
-              </Button>
-            )}
-            {onEdit && (
-              <Button
-                variant="icon"
-                intent="secondary"
-                aria-label="Editar cliente"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEdit();
-                }}
-              >
-                <Icon name="Edit" />
-              </Button>
+                <Icon name="MoreHorizontal" />
+              </ActionMenu>
+            ) : (
+              <>
+                {onContact && (
+                  <Button
+                    variant="icon"
+                    intent="secondary"
+                    aria-label="Contactar"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onContact();
+                    }}
+                  >
+                    <Icon name="Mail" />
+                  </Button>
+                )}
+                {onEdit && (
+                  <Button
+                    variant="icon"
+                    intent="secondary"
+                    aria-label="Editar cliente"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onEdit();
+                    }}
+                  >
+                    <Icon name="Edit" />
+                  </Button>
+                )}
+              </>
             )}
           </div>
         )}
-      </div>
+      </Card>
     );
   },
 );


### PR DESCRIPTION
## Summary
- add optional ActionMenu to `CustomerListItem`
- expose menu props in stories and tests
- wrap list item with `Card`

## Testing
- `npm run test:frontend` *(fails: URL.createObjectURL is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68802f73e320832b9fed6d414b14b3e2