### PR TITLE
Enhance DropdownMenu component

### DIFF
--- a/frontend/src/molecules/DropdownMenu/DropdownMenu.docs.mdx
+++ b/frontend/src/molecules/DropdownMenu/DropdownMenu.docs.mdx
@@ -6,6 +6,7 @@ import { DropdownMenu } from './DropdownMenu';
 # DropdownMenu
 
 The `DropdownMenu` component displays a floating list of actions triggered by a button. Use it for contextual options like user menus or row actions.
+The trigger button can be customized using the `variant`, `intent` and `size` props. You can also control which item is selected via `selectedId`.
 
 <Canvas>
   <Story name="Example">

--- a/frontend/src/molecules/DropdownMenu/DropdownMenu.stories.tsx
+++ b/frontend/src/molecules/DropdownMenu/DropdownMenu.stories.tsx
@@ -11,8 +11,16 @@ const meta: Meta<DropdownMenuProps> = {
     placement: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
     align: { control: 'select', options: ['start', 'center', 'end'] },
     open: { control: 'boolean' },
+    variant: { control: 'select', options: ['default', 'outline', 'ghost', 'glass', 'icon'] },
+    intent: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
+    },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    selectedId: { control: 'text' },
     onSelect: { action: 'select', table: { category: 'Events' } },
     onOpenChange: { action: 'openChange', table: { category: 'Events' } },
+    onSelectedIdChange: { action: 'selectedChange', table: { category: 'Events' } },
   },
 };
 
@@ -27,5 +35,19 @@ export const Default: Story = {
       { label: 'Edit', iconName: 'Edit' },
       { label: 'Delete', iconName: 'Trash2' },
     ],
+    variant: 'outline',
+    intent: 'primary',
+    size: 'md',
+  },
+};
+
+export const WithSelected: Story = {
+  args: {
+    triggerLabel: 'Selected',
+    items: [
+      { label: 'Settings', iconName: 'Settings', id: 'settings' },
+      { label: 'Logout', iconName: 'LogOut', id: 'logout' },
+    ],
+    selectedId: 'settings',
   },
 };

--- a/frontend/src/molecules/DropdownMenu/DropdownMenu.test.tsx
+++ b/frontend/src/molecules/DropdownMenu/DropdownMenu.test.tsx
@@ -44,4 +44,31 @@ describe('DropdownMenu', () => {
     fireEvent.click(document.body);
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
+
+  it('calls onSelectedIdChange when item selected', () => {
+    const onChange = vi.fn();
+    render(
+      <DropdownMenu
+        triggerLabel="Menu"
+        items={[{ label: 'Edit', id: 'edit' }]}
+        onSelectedIdChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('Edit'));
+    expect(onChange).toHaveBeenCalledWith('edit');
+  });
+
+  it('highlights selected item', () => {
+    render(
+      <DropdownMenu
+        triggerLabel="Menu"
+        items={[{ label: 'Edit', id: 'edit' }, { label: 'Delete', id: 'del' }]}
+        selectedId="edit"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    const item = screen.getByText('Edit');
+    expect(item.parentElement).toHaveClass('bg-muted');
+  });
 });


### PR DESCRIPTION
## Summary
- make DropdownMenu trigger customizable via Button props
- allow controlled or uncontrolled selection of menu items
- highlight selected item and emit `onSelectedIdChange`
- document new props and expand Storybook examples
- test selected item behaviour

## Testing
- `pnpm exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802ffd00a8832bbaa2c27eca8a612c