### PR TITLE
Fix DropdownSelect state handling

### DIFF
--- a/frontend/src/molecules/DropdownSelect/DropdownSelect.docs.mdx
+++ b/frontend/src/molecules/DropdownSelect/DropdownSelect.docs.mdx
@@ -13,12 +13,57 @@ The `DropdownSelect` component provides a styled dropdown menu for selecting one
     {() => {
       const [value, setValue] = React.useState('');
       return (
-        <DropdownSelect
-          options={["S", "M", "L", "XL"]}
-          selected={value}
-          onChange={setValue}
-          placeholder="Seleccione"
-        />
+        <div style={{ minHeight: '6rem' }}>
+          <DropdownSelect
+            options={["S", "M", "L", "XL"]}
+            selected={value}
+            onChange={setValue}
+            placeholder="Seleccione"
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## With search
+
+<Canvas>
+  <Story name="Searchable">
+    {() => {
+      const [category, setCategory] = React.useState('');
+      return (
+        <div style={{ minHeight: '6rem' }}>
+          <DropdownSelect
+            options={["Camisas", "Pantalones", "Zapatos", "Accesorios"]}
+            searchable
+            selected={category}
+            onChange={setCategory}
+            placeholder="Categoría"
+          />
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Multiple selection
+
+<Canvas>
+  <Story name="Multiple">
+    {() => {
+      const [colors, setColors] = React.useState<string[]>([]);
+      return (
+        <div style={{ minHeight: '6rem' }}>
+          <DropdownSelect
+            options={["Rojo", "Azul", "Verde", "Negro"]}
+            multiple
+            searchable
+            selected={colors}
+            onChange={setColors}
+            placeholder="Colores"
+          />
+        </div>
       );
     }}
   </Story>

--- a/frontend/src/molecules/DropdownSelect/DropdownSelect.stories.tsx
+++ b/frontend/src/molecules/DropdownSelect/DropdownSelect.stories.tsx
@@ -3,7 +3,7 @@ import { DropdownSelect, DropdownSelectProps } from './DropdownSelect';
 
 interface DropdownSelectStoryProps extends DropdownSelectProps {
   options: string[];
-  selected?: string;
+  selected?: string | string[];
 }
 
 const meta: Meta<DropdownSelectStoryProps> = {
@@ -27,7 +27,24 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const Template = (args: DropdownSelectStoryProps) => {
+  const [value, setValue] = React.useState<string | string[] | undefined>(
+    args.selected,
+  );
+  return (
+    <DropdownSelect
+      {...args}
+      selected={value}
+      onChange={(val) => {
+        setValue(val);
+        args.onChange?.(val);
+      }}
+    />
+  );
+};
+
 export const Default: Story = {
+  render: Template,
   args: {
     options: ['S', 'M', 'L', 'XL'],
     placeholder: 'Seleccione una talla',
@@ -35,6 +52,7 @@ export const Default: Story = {
 };
 
 export const WithSearch: Story = {
+  render: Template,
   args: {
     options: ['Camisas', 'Pantalones', 'Zapatos', 'Accesorios'],
     searchable: true,
@@ -43,6 +61,7 @@ export const WithSearch: Story = {
 };
 
 export const Multiple: Story = {
+  render: Template,
   args: {
     options: ['Rojo', 'Azul', 'Verde', 'Negro'],
     multiple: true,

--- a/frontend/src/molecules/DropdownSelect/DropdownSelect.test.tsx
+++ b/frontend/src/molecules/DropdownSelect/DropdownSelect.test.tsx
@@ -28,6 +28,13 @@ describe('DropdownSelect', () => {
     expect(handleChange).toHaveBeenCalledWith('B');
   });
 
+  it('updates display when uncontrolled', () => {
+    render(<DropdownSelect options={options} />);
+    fireEvent.click(screen.getByRole('textbox'));
+    fireEvent.click(screen.getByText('C'));
+    expect(screen.getByDisplayValue('C')).toBeInTheDocument();
+  });
+
   it('shows search input when searchable', () => {
     render(<DropdownSelect options={options} searchable />);
     fireEvent.click(screen.getByRole('textbox'));

--- a/frontend/src/molecules/DropdownSelect/DropdownSelect.tsx
+++ b/frontend/src/molecules/DropdownSelect/DropdownSelect.tsx
@@ -48,6 +48,14 @@ export const DropdownSelect = React.forwardRef<HTMLDivElement, DropdownSelectPro
     React.useImperativeHandle(ref, () => containerRef.current as HTMLDivElement);
     const [open, setOpen] = React.useState(false);
     const [search, setSearch] = React.useState('');
+    const isControlled = selected !== undefined;
+    const [internalSelected, setInternalSelected] = React.useState<
+      string | string[] | undefined
+    >(selected);
+
+    React.useEffect(() => {
+      if (isControlled) setInternalSelected(selected);
+    }, [isControlled, selected]);
 
     const toggleOpen = () => {
       setOpen((prev) => {
@@ -79,24 +87,32 @@ export const DropdownSelect = React.forwardRef<HTMLDivElement, DropdownSelectPro
       onSearch?.(e.target.value);
     };
 
+    const current = isControlled ? selected : internalSelected;
+
     const isSelected = (opt: string) =>
       multiple
-        ? Array.isArray(selected) && selected.includes(opt)
-        : selected === opt;
+        ? Array.isArray(current) && current.includes(opt)
+        : current === opt;
 
     const handleSelect = (opt: string) => {
       if (multiple) {
-        const arr = Array.isArray(selected) ? [...selected] : [];
+        const arr = Array.isArray(current) ? [...current] : [];
         const exists = arr.includes(opt);
         const newVal = exists ? arr.filter((o) => o !== opt) : [...arr, opt];
+        if (!isControlled) setInternalSelected(newVal);
         onChange?.(newVal);
       } else {
+        if (!isControlled) setInternalSelected(opt);
         onChange?.(opt);
         close();
       }
     };
 
-    const display = multiple ? (Array.isArray(selected) ? selected.join(', ') : '') : selected ?? '';
+    const display = multiple
+      ? Array.isArray(current)
+        ? current.join(', ')
+        : ''
+      : (current as string) ?? '';
 
     const filtered = options.filter((o) => o.toLowerCase().includes(search.toLowerCase()));
 


### PR DESCRIPTION
## Summary
- make DropdownSelect support uncontrolled usage
- update stories to keep selection state
- expand docs with searchable and multiple examples
- test uncontrolled selection behaviour

## Testing
- `npx pnpm --filter erp_system exec vitest run` *(fails: URL.createObjectURL is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688030789de8832b8fff5c40543715b8