### PR TITLE
Fix NotificationIcon badge text and alignment

### DIFF
--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
@@ -5,7 +5,7 @@ import { NotificationIcon } from './NotificationIcon';
 
 # NotificationIcon
 
-The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications.
+The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications. The count text inside the badge is always black for maximum contrast, and large counts are positioned to the right of the icon so they never cover it.
 
 <Canvas>
   <Story name="Examples">

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.stories.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.stories.tsx
@@ -50,3 +50,19 @@ export const Many: Story = {
     count: 120,
   },
 };
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex space-x-2">
+      <NotificationIcon {...args} color="neutral" count={5} />
+      <NotificationIcon {...args} color="success" count={5} />
+      <NotificationIcon {...args} color="warning" count={5} />
+      <NotificationIcon {...args} color="destructive" count={5} />
+      <NotificationIcon {...args} color="info" count={5} />
+    </div>
+  ),
+  args: {
+    iconName: 'Bell',
+    size: 'md',
+  },
+};

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
@@ -24,6 +24,18 @@ describe('NotificationIcon', () => {
     expect(screen.getByText('99+')).toBeInTheDocument();
   });
 
+  it('badge text is black', () => {
+    render(<NotificationIcon count={3} color="success" />);
+    const badge = screen.getByText('3');
+    expect(badge).toHaveClass('text-black');
+  });
+
+  it('positions badge outside icon for large counts', () => {
+    render(<NotificationIcon count={120} />);
+    const badge = screen.getByText('99+');
+    expect(badge.className).toContain('translate-x-1/2');
+  });
+
   it('calls onClick handler', () => {
     const handleClick = vi.fn();
     render(<NotificationIcon count={2} onClick={handleClick} />);

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.tsx
@@ -34,7 +34,7 @@ export const NotificationIcon = React.forwardRef<HTMLButtonElement, Notification
         {showBadge && (
           <Badge
             variant={color}
-            className="absolute -top-1 -right-1 rounded-full px-1 py-0 text-[10px]"
+            className="absolute -top-1 right-0 translate-x-1/2 rounded-full px-1 py-0 text-[10px] text-black"
           >
             {displayCount}
           </Badge>

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,2 +1,13 @@
 // tests/setup.ts
 import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+// Mock URL.createObjectURL for jsdom
+Object.defineProperty(global.URL, 'createObjectURL', {
+  writable: true,
+  value: vi.fn(() => 'blob:mock'),
+});
+Object.defineProperty(global.URL, 'revokeObjectURL', {
+  writable: true,
+  value: vi.fn(),
+});


### PR DESCRIPTION
## Summary
- ensure NotificationIcon badge text is always black and positioned outside the icon
- add color variant story for NotificationIcon
- document new badge behavior
- test badge styling and position
- stub URL.createObjectURL in tests

## Testing
- `pnpm --filter ./frontend exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688031776a58832b81a842ff969e0a11