### PR TITLE
Update OrderItem with action menu

### DIFF
--- a/frontend/src/molecules/OrderItem/OrderItem.docs.mdx
+++ b/frontend/src/molecules/OrderItem/OrderItem.docs.mdx
@@ -6,11 +6,24 @@ import { OrderItem } from './OrderItem';
 # OrderItem
 
 The `OrderItem` component displays a brief summary of an order.
+It can show a customizable icon on the left and an action menu on the right.
 
 <Canvas>
   <Story name="Example">
     <div className="max-w-sm">
-      <OrderItem orderId="#1001" date="12/07/2025" total="$250.00" status="Pendiente" showIcon />
+      <OrderItem
+        orderId="#1001"
+        date="12/07/2025"
+        total="$250.00"
+        status="Pendiente"
+        showIcon
+        iconName="Folder"
+        iconColor="primary"
+        actionOptions={[
+          { label: 'Ver detalles', iconName: 'Search' },
+          { label: 'Cancelar', iconName: 'Trash2' },
+        ]}
+      />
     </div>
   </Story>
 </Canvas>

--- a/frontend/src/molecules/OrderItem/OrderItem.stories.tsx
+++ b/frontend/src/molecules/OrderItem/OrderItem.stories.tsx
@@ -13,8 +13,11 @@ const meta: Meta<OrderItemProps> = {
     total: { control: 'text' },
     status: { control: 'select', options: statusOptions },
     showIcon: { control: 'boolean' },
+    iconName: { control: 'text' },
+    iconColor: { control: 'text' },
+    actionOptions: { control: 'object' },
     onSelect: { action: 'orderSelected' },
-    onActionClick: { action: 'actionClicked' },
+    onActionSelect: { action: 'actionSelected' },
   },
 };
 export default meta;
@@ -28,6 +31,7 @@ export const Default: Story = {
     total: '$250.00',
     status: 'Pendiente',
     showIcon: true,
+    iconName: 'File',
   },
 };
 
@@ -41,13 +45,16 @@ export const WithoutIcon: Story = {
   },
 };
 
-export const WithAction: Story = {
+export const WithActions: Story = {
   args: {
     orderId: '#1003',
     date: '18/07/2025',
     total: '$90.00',
     status: 'En ruta',
     showIcon: true,
-    onActionClick: () => {},
+    actionOptions: [
+      { label: 'Ver detalles', iconName: 'Search' },
+      { label: 'Cancelar', iconName: 'Trash2' },
+    ],
   },
 };

--- a/frontend/src/molecules/OrderItem/OrderItem.test.tsx
+++ b/frontend/src/molecules/OrderItem/OrderItem.test.tsx
@@ -21,6 +21,8 @@ describe('OrderItem', () => {
         total="$20"
         status="Entregado"
         showIcon
+        iconName="Folder"
+        iconColor="primary"
       />,
     );
     const icon = screen.getByTestId('order-icon');
@@ -42,19 +44,26 @@ describe('OrderItem', () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
-  it('calls action button handler', () => {
-    const onActionClick = vi.fn();
+  it('calls action menu handler', () => {
+    const onActionSelect = vi.fn();
     render(
       <OrderItem
         orderId="#4"
         date="01/01/2024"
         total="$40"
         status="Cancelado"
-        onActionClick={onActionClick}
+        actionOptions={[
+          { label: 'Detalles', iconName: 'Search' },
+          { label: 'Eliminar', iconName: 'Trash2' },
+        ]}
+        onActionSelect={onActionSelect}
       />,
     );
-    const button = screen.getByRole('button', { name: /acciones/i });
-    fireEvent.click(button);
-    expect(onActionClick).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: /acciones/i }));
+    fireEvent.click(screen.getByText('Eliminar'));
+    expect(onActionSelect).toHaveBeenCalledWith(
+      { label: 'Eliminar', iconName: 'Trash2' },
+      1,
+    );
   });
 });

--- a/frontend/src/molecules/OrderItem/OrderItem.tsx
+++ b/frontend/src/molecules/OrderItem/OrderItem.tsx
@@ -4,9 +4,9 @@ import { cn } from '@/lib/utils';
 import { Card } from '@/atoms/Card';
 import { Text } from '@/atoms/Text';
 import { Badge, type BadgeProps } from '@/atoms/Badge';
-import { Icon } from '@/atoms/Icon';
-import { Button } from '@/atoms/Button/Button';
+import { Icon, type IconName, type IconProps } from '@/atoms/Icon';
 import { MoreHorizontal } from 'lucide-react';
+import { ActionMenu, type ActionMenuOption } from '@/molecules/ActionMenu';
 
 export type OrderStatus = 'Entregado' | 'Pendiente' | 'Cancelado' | 'En ruta';
 
@@ -36,10 +36,16 @@ export interface OrderItemProps extends React.HTMLAttributes<HTMLDivElement> {
   status: OrderStatus;
   /** Show the leading icon */
   showIcon?: boolean;
+  /** Name of the icon to display */
+  iconName?: IconName;
+  /** Color of the icon */
+  iconColor?: IconProps['color'];
   /** Fired when the item is clicked */
   onSelect?: () => void;
-  /** Fired when the action button is clicked */
-  onActionClick?: () => void;
+  /** Options for the action menu */
+  actionOptions?: ActionMenuOption[];
+  /** Fired when an action is selected */
+  onActionSelect?: (option: ActionMenuOption, index: number) => void;
 }
 
 export const OrderItem = React.forwardRef<HTMLDivElement, OrderItemProps>(
@@ -50,8 +56,11 @@ export const OrderItem = React.forwardRef<HTMLDivElement, OrderItemProps>(
       total,
       status,
       showIcon = false,
+      iconName = 'File',
+      iconColor = 'secondary',
       onSelect,
-      onActionClick,
+      actionOptions,
+      onActionSelect,
       className,
       ...props
     },
@@ -68,10 +77,6 @@ export const OrderItem = React.forwardRef<HTMLDivElement, OrderItemProps>(
       }
     };
 
-    const handleAction = (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.stopPropagation();
-      onActionClick?.();
-    };
 
     return (
       <Card
@@ -86,11 +91,11 @@ export const OrderItem = React.forwardRef<HTMLDivElement, OrderItemProps>(
       >
         {showIcon && (
           <Icon
-            name="File"
+            name={iconName}
             size="lg"
+            color={iconColor}
             aria-hidden="true"
             data-testid="order-icon"
-            className="text-secondary"
           />
         )}
         <div className="flex flex-1 flex-col gap-1 sm:flex-row sm:items-center">
@@ -107,17 +112,16 @@ export const OrderItem = React.forwardRef<HTMLDivElement, OrderItemProps>(
         <Badge variant={badgeVariant} className="ml-2 whitespace-nowrap">
           {status}
         </Badge>
-        {onActionClick && (
-          <Button
-            variant="icon"
-            intent="secondary"
-            size="sm"
+        {actionOptions && actionOptions.length > 0 && (
+          <ActionMenu
+            options={actionOptions}
+            onOptionSelect={onActionSelect}
+            position="bottom-right"
             aria-label="Acciones"
-            onClick={handleAction}
             className="ml-2"
           >
             <MoreHorizontal size={16} />
-          </Button>
+          </ActionMenu>
         )}
       </Card>
     );


### PR DESCRIPTION
## Summary
- add action menu integration to `OrderItem`
- allow customizing icon name and color
- document new behaviour in MDX and stories
- adjust tests for action menu support

## Testing
- `npx vitest run src/molecules/OrderItem/OrderItem.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688031db4e18832baa3e0d9a628628f0