### PR TITLE
Fix OrderListItem action alignment

### DIFF
--- a/frontend/src/molecules/OrderListItem/OrderListItem.docs.mdx
+++ b/frontend/src/molecules/OrderListItem/OrderListItem.docs.mdx
@@ -16,6 +16,14 @@ The `OrderListItem` component represents a single order in a list. It displays t
       total="$250.00"
       status="Pendiente"
     />
+    <OrderListItem
+      orderId="1002"
+      date="02/09/2025"
+      customerName="Maria Lopez"
+      total="$100.00"
+      status="Enviado"
+      showActions
+    />
   </Story>
 </Canvas>
 

--- a/frontend/src/molecules/OrderListItem/OrderListItem.test.tsx
+++ b/frontend/src/molecules/OrderListItem/OrderListItem.test.tsx
@@ -19,8 +19,11 @@ describe('OrderListItem', () => {
   });
 
   it('shows action button when enabled', () => {
-    render(<OrderListItem {...baseProps} showActions />);
+    const { container } = render(<OrderListItem {...baseProps} showActions />);
     expect(screen.getByLabelText('Acciones')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass(
+      'grid-cols-[auto_auto_1fr_auto_auto_auto]',
+    );
   });
 
   it('calls onClick handler', () => {

--- a/frontend/src/molecules/OrderListItem/OrderListItem.tsx
+++ b/frontend/src/molecules/OrderListItem/OrderListItem.tsx
@@ -7,16 +7,21 @@ import { Button } from '@/atoms/Button/Button';
 import { Icon } from '@/atoms/Icon';
 
 const orderListItemVariants = cva(
-  'grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-2 px-3 py-2 text-sm rounded-md',
+  'grid items-center gap-2 px-3 py-2 text-sm rounded-md',
   {
     variants: {
       clickable: {
         true: 'hover:bg-muted cursor-pointer',
         false: '',
       },
+      showActions: {
+        true: 'grid-cols-[auto_auto_1fr_auto_auto_auto]',
+        false: 'grid-cols-[auto_auto_1fr_auto_auto]',
+      },
     },
     defaultVariants: {
       clickable: true,
+      showActions: false,
     },
   },
 );
@@ -74,7 +79,7 @@ export const OrderListItem = React.forwardRef<HTMLDivElement, OrderListItemProps
     return (
       <div
         ref={ref}
-        className={cn(orderListItemVariants({ clickable }), className)}
+        className={cn(orderListItemVariants({ clickable, showActions }), className)}
         onClick={onClick}
         {...props}
       >


### PR DESCRIPTION
## Summary
- fix grid layout when `showActions` is true so the button is inline
- update test accordingly
- document actions in OrderListItem docs

## Testing
- `pnpm test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_6880322b3abc832b83c2f2d73f721821