### PR TITLE
Improve PaginationControls display

### DIFF
--- a/frontend/src/molecules/PaginationControls/PaginationControls.docs.mdx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.docs.mdx
@@ -6,10 +6,11 @@ import { PaginationControls } from './PaginationControls';
 # PaginationControls
 
 The `PaginationControls` component provides buttons for navigating between pages of results.
+When the total number of pages exceeds five, intermediate pages collapse into an ellipsis.
 
 <Canvas>
   <Story name="Example">
-    <PaginationControls currentPage={3} totalPages={10} onPageChange={(page) => console.log(page)} />
+    <PaginationControls currentPage={3} totalPages={8} onPageChange={(page) => console.log(page)} />
   </Story>
 </Canvas>
 

--- a/frontend/src/molecules/PaginationControls/PaginationControls.stories.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
 export const ManyPages: Story = {
   args: {
     currentPage: 5,
-    totalPages: 20,
+    totalPages: 8,
     siblings: 1,
     showFirstLast: true,
   },

--- a/frontend/src/molecules/PaginationControls/PaginationControls.test.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.test.tsx
@@ -33,4 +33,16 @@ describe('PaginationControls', () => {
     );
     expect(screen.getAllByText('...').length).toBeGreaterThan(0);
   });
+
+  it('shows dots when pages exceed five', () => {
+    render(<PaginationControls currentPage={3} totalPages={6} />);
+    expect(screen.getAllByText('...').length).toBeGreaterThan(0);
+  });
+
+  it('uses square buttons', () => {
+    render(<PaginationControls currentPage={1} totalPages={3} />);
+    const btn = screen.getByRole('button', { name: '1' });
+    expect(btn.className).toMatch(/w-8/);
+    expect(btn.className).toMatch(/h-8/);
+  });
 });

--- a/frontend/src/molecules/PaginationControls/PaginationControls.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.tsx
@@ -20,15 +20,18 @@ export interface PaginationControlsProps extends React.HTMLAttributes<HTMLDivEle
 
 type PageItem = number | 'dots';
 
+const MAX_VISIBLE_PAGES = 5;
+
 function getPageRange(total: number, current: number, siblings: number): PageItem[] {
   const range: PageItem[] = [];
-  const totalNumbers = siblings * 2 + 3; // current, siblings on both sides, first and last
-  const totalBlocks = totalNumbers + 2; // with two dots
 
-  if (total <= totalBlocks) {
+  if (total <= MAX_VISIBLE_PAGES) {
     for (let i = 1; i <= total; i++) range.push(i);
     return range;
   }
+
+  const totalNumbers = siblings * 2 + 3; // current, siblings on both sides, first and last
+  const totalBlocks = totalNumbers + 2; // with two dots
 
   const leftSiblingIndex = Math.max(current - siblings, 2);
   const rightSiblingIndex = Math.min(current + siblings, total - 1);
@@ -73,6 +76,7 @@ export const PaginationControls = React.forwardRef<HTMLDivElement, PaginationCon
     );
 
     const buttonVariant = 'ghost';
+    const baseButtonClass = 'w-8 h-8 p-0 !min-w-0 rounded-md';
 
     return (
       <div ref={ref} className={cn('flex items-center justify-center gap-2', className)} {...props}>
@@ -80,6 +84,7 @@ export const PaginationControls = React.forwardRef<HTMLDivElement, PaginationCon
           <Button
             variant={buttonVariant}
             size="sm"
+            className={baseButtonClass + ' border'}
             disabled={disabled || currentPage === 1}
             onClick={() => handleChange(1)}
             aria-label="First page"
@@ -91,6 +96,7 @@ export const PaginationControls = React.forwardRef<HTMLDivElement, PaginationCon
         <Button
           variant={buttonVariant}
           size="sm"
+          className={baseButtonClass + ' border'}
           disabled={disabled || currentPage === 1}
           onClick={() => handleChange(currentPage - 1)}
           aria-label="Previous page"
@@ -108,6 +114,7 @@ export const PaginationControls = React.forwardRef<HTMLDivElement, PaginationCon
               variant={page === currentPage ? 'default' : buttonVariant}
               intent="primary"
               size="sm"
+              className={cn(baseButtonClass, page === currentPage ? '' : 'border border-border')}
               disabled={disabled}
               onClick={() => handleChange(page)}
               aria-current={page === currentPage ? 'page' : undefined}
@@ -119,6 +126,7 @@ export const PaginationControls = React.forwardRef<HTMLDivElement, PaginationCon
         <Button
           variant={buttonVariant}
           size="sm"
+          className={baseButtonClass + ' border'}
           disabled={disabled || currentPage === totalPages}
           onClick={() => handleChange(currentPage + 1)}
           aria-label="Next page"
@@ -129,6 +137,7 @@ export const PaginationControls = React.forwardRef<HTMLDivElement, PaginationCon
           <Button
             variant={buttonVariant}
             size="sm"
+            className={baseButtonClass + ' border'}
             disabled={disabled || currentPage === totalPages}
             onClick={() => handleChange(totalPages)}
             aria-label="Last page"


### PR DESCRIPTION
## Summary
- shrink pagination buttons to square icons
- limit visible pages to a maximum of five before using ellipsis
- update stories and documentation
- extend tests for ellipsis logic and new styling

## Testing
- `npx --yes vitest run frontend/src/molecules/PaginationControls/PaginationControls.test.tsx` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_688032d65d40832bb8b9dace0536554d