### PR TITLE
Improve ProductCard design and docs

### DIFF
--- a/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
+++ b/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { ImageUploader } from './ImageUploader';
 
 const createFile = (name: string) => new File(['hello'], name, { type: 'image/png' });
+
+beforeAll(() => {
+  (global as any).URL.createObjectURL = vi.fn(() => 'preview');
+  (global as any).URL.revokeObjectURL = vi.fn();
+});
 
 describe('ImageUploader', () => {
   it('renders upload button', () => {

--- a/frontend/src/molecules/ProductCard/ProductCard.docs.mdx
+++ b/frontend/src/molecules/ProductCard/ProductCard.docs.mdx
@@ -6,11 +6,22 @@ import { ProductCard } from './ProductCard';
 # ProductCard
 
 La `ProductCard` muestra de forma resumida la información principal de un producto de inventario. Utiliza los átomos existentes para construir una tarjeta con imagen, nombre, precio y estados.
+La imagen se muestra con una proporción fija 3:4 para mantener consistencia en los listados.
 
 <Canvas>
   <Story name="Ejemplo">
     <div className="w-64">
-      <ProductCard productName="Camisa de Lino" price="$49.99" imageSrc="https://via.placeholder.com/300x200" />
+      <ProductCard productName="Camisa de Lino" price="$49.99" />
+    </div>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Grid">
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 max-w-3xl">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <ProductCard key={i} productName={`Producto ${i + 1}`} price="$19.99" />
+      ))}
     </div>
   </Story>
 </Canvas>

--- a/frontend/src/molecules/ProductCard/ProductCard.stories.tsx
+++ b/frontend/src/molecules/ProductCard/ProductCard.stories.tsx
@@ -32,7 +32,7 @@ export const Default: Story = {
   args: {
     productName: 'Camisa de Lino',
     price: '$49.99',
-    imageSrc: 'https://via.placeholder.com/300x200',
+    imageSrc: undefined,
     outOfStock: false,
     onSale: false,
     clickable: true,
@@ -65,4 +65,22 @@ export const WithActions: Story = {
     price: '$49.99',
     showActions: true,
   },
+};
+
+interface GridStoryProps extends ProductCardProps {
+  numCards: number;
+}
+
+export const Grid: StoryObj<GridStoryProps> = {
+  args: { numCards: 4, productName: 'Producto', price: '$19.99' },
+  argTypes: {
+    numCards: { control: { type: 'number', min: 1, max: 8, step: 1 } },
+  },
+  render: ({ numCards, ...args }) => (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 max-w-3xl">
+      {Array.from({ length: numCards }).map((_, i) => (
+        <ProductCard key={i} {...args} productName={`${args.productName} ${i + 1}`} />
+      ))}
+    </div>
+  ),
 };

--- a/frontend/src/molecules/ProductCard/ProductCard.tsx
+++ b/frontend/src/molecules/ProductCard/ProductCard.tsx
@@ -22,7 +22,9 @@ export interface ProductCardProps extends React.HTMLAttributes<HTMLDivElement> {
   onDelete?: () => void;
 }
 
-const placeholderImg = 'https://via.placeholder.com/300x200?text=Imagen';
+// Realistic unsplash photo used as fallback image
+const placeholderImg =
+  'https://images.unsplash.com/photo-1513708926704-99d6fa04d638?auto=format&fit=crop&w=600&q=60';
 
 export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
   (
@@ -50,7 +52,7 @@ export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
       }
     };
 
-    const imageClasses = cn('h-40 w-full object-cover rounded-md', outOfStock && 'opacity-50');
+    const imageClasses = cn('h-full w-full object-cover', outOfStock && 'opacity-50');
 
     const statusColor = statusBadge === 'Agotado'
       ? 'destructive'
@@ -68,7 +70,7 @@ export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
         className={cn('w-full space-y-2', className)}
         {...props}
       >
-        <div className="relative">
+        <div className="relative overflow-hidden rounded-md aspect-[3/4]">
           <img
             src={imageSrc || placeholderImg}
             alt={productName}
@@ -129,18 +131,18 @@ export const ProductCard = React.forwardRef<HTMLDivElement, ProductCardProps>(
           )}
         </div>
         <div className="flex items-start justify-between gap-2">
-          <Heading level={4} className="flex-1 text-sm truncate">
+          <Heading level={4} className="flex-1 text-sm truncate flex items-center gap-2">
             {productName}
+            {statusBadge && (
+              <Tag variant="solid" color={statusColor} className="text-xs">
+                {statusBadge}
+              </Tag>
+            )}
           </Heading>
-          <Text as="span" weight="semibold" color="secondary">
+          <Text as="span" weight="semibold" color="secondary" className="text-base">
             {price}
           </Text>
         </div>
-        {statusBadge && (
-          <Tag variant="solid" color={statusColor} className="text-xs">
-            {statusBadge}
-          </Tag>
-        )}
       </Card>
     );
   },


### PR DESCRIPTION
## Summary
- improve ProductCard styling: use unsplash placeholder, 3:4 aspect image container
- show status tag beside product name and enlarge price
- demonstrate usage in docs and add grid example
- allow interactive grid story
- fix ImageUploader tests by mocking URL methods

## Testing
- `pnpm --filter erp_system exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6880340bbb48832b98c905307147db7e