### PR TITLE
Improve StatCard with trend indicators

### DIFF
--- a/frontend/src/atoms/Icon/icons.ts
+++ b/frontend/src/atoms/Icon/icons.ts
@@ -26,6 +26,8 @@ import {
   User,
   Heart,
   Star,
+  TrendingUp,
+  TrendingDown,
   X,
 } from 'lucide-react';
 
@@ -57,6 +59,8 @@ export const iconMap = {
   User,
   Heart,
   Star,
+  TrendingUp,
+  TrendingDown,
   X,
 };
 

--- a/frontend/src/molecules/StatCard/StatCard.docs.mdx
+++ b/frontend/src/molecules/StatCard/StatCard.docs.mdx
@@ -5,13 +5,30 @@ import { StatCard } from './StatCard';
 
 # StatCard
 
-The `StatCard` component highlights a single metric or KPI using the `Card` atom. It can optionally display an icon and be made clickable.
+The `StatCard` component highlights a single metric or KPI using the `Card` atom. It can optionally display an icon and be made clickable. The component also supports trend indicators, progress bars and a simple sparkline to visualise data.
 
 <Canvas>
   <Story name="Examples">
     <div className="grid grid-cols-2 gap-4 max-w-sm">
-      <StatCard value="120" label="Nuevos Pedidos" iconName="Folder" />
-      <StatCard value="$5,000" label="Ventas" iconName="File" variant="outline" />
+      <StatCard
+        value="120"
+        label="Nuevos Pedidos"
+        iconName="Folder"
+        progress={60}
+        trend="up"
+        trendValue="12%"
+        sparklineData={[10, 20, 15, 30, 25]}
+      />
+      <StatCard
+        value="$5,000"
+        label="Ventas"
+        iconName="File"
+        variant="outline"
+        trend="down"
+        trendValue="-8%"
+        progress={30}
+        sparklineData={[30, 25, 20, 15, 10]}
+      />
     </div>
   </Story>
 </Canvas>

--- a/frontend/src/molecules/StatCard/StatCard.stories.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.stories.tsx
@@ -16,6 +16,10 @@ const meta: Meta<StatCardStoryProps> = {
     value: { control: 'text' },
     label: { control: 'text' },
     iconName: { control: 'select', options: iconOptions },
+    trend: { control: 'select', options: ['up', 'down'] },
+    trendValue: { control: 'text' },
+    progress: { control: 'number' },
+    sparklineData: { control: 'object' },
     variant: { control: 'select', options: ['shadow', 'outline', 'glass'] },
     clickable: { control: 'boolean' },
     onClick: { action: 'clicked', table: { category: 'Events' } },
@@ -33,6 +37,10 @@ export const Default: Story = {
     iconName: 'Folder',
     variant: 'shadow',
     clickable: false,
+    progress: 60,
+    trend: 'up',
+    trendValue: '12%',
+    sparklineData: [10, 20, 15, 30, 25],
   },
 };
 
@@ -42,5 +50,9 @@ export const Clickable: Story = {
     label: 'Ventas',
     iconName: 'File',
     clickable: true,
+    trend: 'down',
+    trendValue: '-8%',
+    progress: 30,
+    sparklineData: [30, 25, 20, 15, 10],
   },
 };

--- a/frontend/src/molecules/StatCard/StatCard.test.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.test.tsx
@@ -30,4 +30,20 @@ describe('StatCard', () => {
     const card = screen.getByText('5').closest('div');
     expect(card?.className).toContain('cursor-pointer');
   });
+
+  it('renders progress bar when progress prop is set', () => {
+    const { container } = render(<StatCard value="5" label="Progress" progress={50} />);
+    expect(container.querySelector('div[role="progressbar"]')).toBeInTheDocument();
+  });
+
+  it('shows trend icon when trend is provided', () => {
+    const { container } = render(<StatCard value="5" label="Trend" trend="up" />);
+    const icon = container.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders sparkline when data supplied', () => {
+    const { container } = render(<StatCard value="5" label="Spark" sparklineData={[1,2,3]} />);
+    expect(container.querySelector('polyline')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/molecules/StatCard/StatCard.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.tsx
@@ -3,6 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { Card, type CardProps } from '@/atoms/Card';
 import { Icon, type IconName } from '@/atoms/Icon';
+import { ProgressBar } from '@/atoms/ProgressBar';
 import { Text } from '@/atoms/Text';
 import { cn } from '@/lib/utils';
 
@@ -27,13 +28,59 @@ export interface StatCardProps
   label: string;
   /** Optional icon name to display */
   iconName?: IconName;
+  /** Show an arrow indicating trend direction */
+  trend?: 'up' | 'down';
+  /** Optional value to display next to the trend arrow */
+  trendValue?: string | number;
+  /** Progress percentage to visualize with a bar */
+  progress?: number;
+  /** Data points for a small sparkline graph */
+  sparklineData?: number[];
 }
 
 export const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
   (
-    { value, label, iconName, variant, clickable, orientation, className, ...props },
+    {
+      value,
+      label,
+      iconName,
+      trend,
+      trendValue,
+      progress,
+      sparklineData,
+      variant,
+      clickable,
+      orientation,
+      className,
+      ...props
+    },
     ref,
   ) => {
+    const renderSparkline = (data?: number[]) => {
+      if (!data || data.length < 2) return null;
+      const w = 64;
+      const h = 24;
+      const min = Math.min(...data);
+      const max = Math.max(...data);
+      const range = max - min || 1;
+      const points = data
+        .map((d, i) => {
+          const x = (i / (data.length - 1)) * w;
+          const y = h - ((d - min) / range) * h;
+          return `${x},${y}`;
+        })
+        .join(' ');
+      return (
+        <svg
+          viewBox={`0 0 ${w} ${h}`}
+          className="mt-2 h-6 w-full stroke-muted-foreground"
+          fill="none"
+        >
+          <polyline points={points} strokeWidth={1.5} />
+        </svg>
+      );
+    };
+
     return (
       <Card
         ref={ref}
@@ -49,12 +96,33 @@ export const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
             aria-hidden="true"
           />
         )}
-        <Text as="span" className="text-3xl font-semibold">
-          {value}
-        </Text>
+        <span className="flex items-center gap-1">
+          <Text as="span" className="text-3xl font-semibold">
+            {value}
+          </Text>
+          {trend && (
+            <Icon
+              name={trend === 'up' ? 'TrendingUp' : 'TrendingDown'}
+              className={cn(
+                'h-4 w-4',
+                trend === 'up' ? 'text-success' : 'text-destructive',
+              )}
+              aria-hidden="true"
+            />
+          )}
+          {trendValue && (
+            <Text as="span" className="text-xs text-muted-foreground">
+              {trendValue}
+            </Text>
+          )}
+        </span>
         <Text as="span" className="text-sm text-muted-foreground">
           {label}
         </Text>
+        {renderSparkline(sparklineData)}
+        {progress !== undefined && (
+          <ProgressBar value={progress} size="sm" className="mt-2" />
+        )}
       </Card>
     );
   },


### PR DESCRIPTION
## Summary
- add TrendingUp/TrendingDown to icon map
- enhance StatCard with trend arrows, progress bar and optional sparkline
- document new StatCard features in stories and docs
- update unit tests

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68803479af74832b8f2a012023f12f55