### PR TITLE
Fix StepIndicator bounds and docs

### DIFF
--- a/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
+++ b/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { ImageUploader } from './ImageUploader';
 
 const createFile = (name: string) => new File(['hello'], name, { type: 'image/png' });
+
+beforeAll(() => {
+  (global as any).URL.createObjectURL = vi.fn(() => 'preview');
+  (global as any).URL.revokeObjectURL = vi.fn();
+});
 
 describe('ImageUploader', () => {
   it('renders upload button', () => {

--- a/frontend/src/molecules/StepIndicator/StepIndicator.docs.mdx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.docs.mdx
@@ -7,6 +7,8 @@ import { StepIndicator } from './StepIndicator';
 
 The `StepIndicator` component displays progress through a multi-step process. Each step shows a numbered circle or a checkmark when completed.
 
+It supports up to **15** steps. If `currentStep` exceeds the total, it will be clamped to the last step.
+
 <Canvas>
   <Story name="Example">
     <StepIndicator

--- a/frontend/src/molecules/StepIndicator/StepIndicator.stories.tsx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.stories.tsx
@@ -6,8 +6,8 @@ const meta: Meta<StepIndicatorProps> = {
   component: StepIndicator,
   tags: ['autodocs'],
   argTypes: {
-    totalSteps: { control: { type: 'number', min: 1 } },
-    currentStep: { control: { type: 'number', min: 1 } },
+    totalSteps: { control: { type: 'number', min: 1, max: 15 } },
+    currentStep: { control: { type: 'number', min: 1, max: 15 } },
     labels: { control: 'object' },
     clickable: { control: 'boolean' },
     onStepClick: { action: 'stepClicked' },

--- a/frontend/src/molecules/StepIndicator/StepIndicator.test.tsx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.test.tsx
@@ -34,4 +34,20 @@ describe('StepIndicator', () => {
     fireEvent.click(screen.getAllByRole('button')[1]);
     expect(handle).not.toHaveBeenCalled();
   });
+
+  it('caps totalSteps at 15', () => {
+    render(<StepIndicator totalSteps={20} currentStep={1} />);
+    expect(screen.getAllByRole('button')).toHaveLength(15);
+  });
+
+  it('clamps currentStep to totalSteps', () => {
+    render(<StepIndicator totalSteps={3} currentStep={10} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[buttons.length - 1].textContent).toBe('3');
+  });
+
+  it('handles null labels gracefully', () => {
+    render(<StepIndicator totalSteps={2} currentStep={1} labels={null as any} />);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
 });

--- a/frontend/src/molecules/StepIndicator/StepIndicator.tsx
+++ b/frontend/src/molecules/StepIndicator/StepIndicator.tsx
@@ -46,7 +46,7 @@ export const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps
     {
       totalSteps,
       currentStep,
-      labels = [],
+      labels,
       clickable = false,
       onStepClick,
       className,
@@ -54,16 +54,22 @@ export const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps
     },
     ref,
   ) => {
-    const steps = Array.from({ length: totalSteps }, (_, i) => i + 1);
+    const safeTotal = Math.min(Math.max(totalSteps, 1), 15);
+    const safeCurrent = Math.min(Math.max(currentStep, 1), safeTotal);
+
+    const steps = Array.from({ length: safeTotal }, (_, i) => i + 1);
+    const safeLabels = Array.isArray(labels) ? labels.slice(0, safeTotal) : [];
     const finalLabels =
-      labels.length === totalSteps ? labels : steps.map((n) => `Paso ${n}`);
+      safeLabels.length === safeTotal
+        ? safeLabels
+        : steps.map((n) => `Paso ${n}`);
 
     return (
       <div ref={ref} className={cn('flex items-center w-full', className)} {...props}>
         {steps.map((step, index) => {
           const state =
-            step < currentStep ? 'completed' : step === currentStep ? 'current' : 'pending';
-          const isClickable = clickable && step < currentStep;
+            step < safeCurrent ? 'completed' : step === safeCurrent ? 'current' : 'pending';
+          const isClickable = clickable && step < safeCurrent;
           const handleClick = () => {
             if (isClickable) onStepClick?.(step);
           };
@@ -90,7 +96,7 @@ export const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps
                 <div
                   className={cn(
                     'mx-2 flex-1 border-t',
-                    step < currentStep ? 'border-success' : 'border-border',
+                    step < safeCurrent ? 'border-success' : 'border-border',
                   )}
                 />
               )}


### PR DESCRIPTION
## Summary
- clamp step counts and labels in StepIndicator
- document max steps and clamp behaviour
- limit step controls in Storybook
- expand StepIndicator tests
- stub URL methods in ImageUploader tests

## Testing
- `pnpm --filter erp_system exec vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_68803503cc10832bb5ccb72e5c6a9863