### PR TITLE
Fix TagInput state reset and add controlled example

### DIFF
--- a/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
+++ b/frontend/src/molecules/ImageUploader/ImageUploader.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { ImageUploader } from './ImageUploader';
 
 const createFile = (name: string) => new File(['hello'], name, { type: 'image/png' });
 
 describe('ImageUploader', () => {
+  beforeAll(() => {
+    (global as any).URL.createObjectURL = vi.fn(() => 'preview');
+    (global as any).URL.revokeObjectURL = vi.fn();
+  });
   it('renders upload button', () => {
     render(<ImageUploader />);
     expect(screen.getByRole('button')).toBeInTheDocument();

--- a/frontend/src/molecules/TagInput/TagInput.docs.mdx
+++ b/frontend/src/molecules/TagInput/TagInput.docs.mdx
@@ -8,9 +8,17 @@ import { TagInput } from './TagInput';
 
 The `TagInput` component allows users to enter multiple tags in a single field. Each tag is displayed as a closable chip inside the input.
 
+`tags` can be provided to set the initial list, but the component manages its own state. For a controlled usage combine `tags` and `onChange`.
+
 <Canvas>
   <Story name="Ejemplo">
     {() => <TagInput placeholder="Agregar etiquetas..." />}
+  </Story>
+  <Story name="Controlado">
+    {() => {
+      const [tags, setTags] = React.useState<string[]>(['react']);
+      return <TagInput tags={tags} onChange={setTags} />;
+    }}
   </Story>
 </Canvas>
 

--- a/frontend/src/molecules/TagInput/TagInput.stories.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.stories.tsx
@@ -56,3 +56,13 @@ export const Limited: Story = {
     placeholder: 'Máximo 3',
   },
 };
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [tags, setTags] = React.useState<string[]>(args.tags ?? []);
+    return <TagInput {...args} tags={tags} onChange={setTags} />;
+  },
+  args: {
+    placeholder: 'Controlado',
+  },
+};

--- a/frontend/src/molecules/TagInput/TagInput.test.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.test.tsx
@@ -17,6 +17,16 @@ describe('TagInput', () => {
     expect(screen.getByText('new')).toBeInTheDocument();
   });
 
+  it('persists added tags after rerender when uncontrolled', () => {
+    const { rerender } = render(<TagInput placeholder="add" />);
+    const input = screen.getByPlaceholderText('add');
+    fireEvent.change(input, { target: { value: 'stay' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByText('stay')).toBeInTheDocument();
+    rerender(<TagInput placeholder="add" />);
+    expect(screen.getByText('stay')).toBeInTheDocument();
+  });
+
   it('removes tag when close clicked', () => {
     render(<TagInput tags={['remove']} />);
     fireEvent.click(screen.getByRole('button'));

--- a/frontend/src/molecules/TagInput/TagInput.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.tsx
@@ -30,7 +30,7 @@ export interface TagInputProps
 export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
   (
     {
-      tags: initialTags = [],
+      tags,
       placeholder,
       separators = ',',
       maxTags,
@@ -47,40 +47,42 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
     },
     ref,
   ) => {
-    const [tags, setTags] = React.useState<string[]>(initialTags);
+    const [tagList, setTagList] = React.useState<string[]>(tags ?? []);
     const [inputValue, setInputValue] = React.useState('');
     const inputRef = React.useRef<HTMLInputElement>(null);
 
     React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
     React.useEffect(() => {
-      setTags(initialTags);
-    }, [initialTags]);
+      if (tags !== undefined) {
+        setTagList(tags);
+      }
+    }, [tags]);
 
     const addTag = React.useCallback(
       (value: string) => {
         const trimmed = value.trim();
         if (!trimmed) return;
-        if (maxTags && tags.length >= maxTags) return;
-        if (tags.includes(trimmed)) return;
-        const newTags = [...tags, trimmed];
-        setTags(newTags);
+        if (maxTags && tagList.length >= maxTags) return;
+        if (tagList.includes(trimmed)) return;
+        const newTags = [...tagList, trimmed];
+        setTagList(newTags);
         onTagAdd?.(trimmed);
         onChange?.(newTags);
         setInputValue('');
       },
-      [tags, maxTags, onTagAdd, onChange],
+      [tagList, maxTags, onTagAdd, onChange],
     );
 
     const removeTag = React.useCallback(
       (index: number) => {
-        const removed = tags[index];
-        const newTags = tags.filter((_, i) => i !== index);
-        setTags(newTags);
+        const removed = tagList[index];
+        const newTags = tagList.filter((_, i) => i !== index);
+        setTagList(newTags);
         onTagRemove?.(removed, index);
         onChange?.(newTags);
       },
-      [tags, onTagRemove, onChange],
+      [tagList, onTagRemove, onChange],
     );
 
     const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
@@ -88,7 +90,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
         e.preventDefault();
         addTag(inputValue);
       } else if (e.key === 'Backspace' && inputValue === '') {
-        removeTag(tags.length - 1);
+        removeTag(tagList.length - 1);
       }
     };
 
@@ -107,7 +109,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
         )}
         onClick={() => inputRef.current?.focus()}
       >
-        {tags.map((tag, i) => (
+        {tagList.map((tag, i) => (
           <Tag
             key={`${tag}-${i}`}
             color={tagColor}
@@ -125,7 +127,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
           value={inputValue}
           onKeyDown={handleKeyDown}
           onChange={handleChange}
-          placeholder={tags.length === 0 ? placeholder : undefined}
+          placeholder={tagList.length === 0 ? placeholder : undefined}
           className="m-1 flex-1 bg-transparent focus:outline-none"
           {...props}
         />


### PR DESCRIPTION
## Summary
- ensure `TagInput` keeps tags across rerenders
- improve TagInput tests
- document controlled TagInput usage
- add controlled storybook example
- fix ImageUploader tests to stub URL methods

## Testing
- `pnpm run test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_688035783b28832b8897502010bf677c