### PR TITLE
Fix DropdownSelect story

### DIFF
--- a/frontend/src/molecules/DropdownSelect/DropdownSelect.stories.tsx
+++ b/frontend/src/molecules/DropdownSelect/DropdownSelect.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
 import { DropdownSelect, DropdownSelectProps } from './DropdownSelect';
 
 interface DropdownSelectStoryProps extends DropdownSelectProps {


### PR DESCRIPTION
## Summary
- import React for DropdownSelect stories to fix ReferenceError

## Testing
- `pnpm test:frontend` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_688042693484832baeb2cdf243d01b3c