### PR TITLE
Remove unused action variant in CustomerCard

### DIFF
--- a/frontend/src/molecules/CustomerCard/CustomerCard.docs.mdx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.docs.mdx
@@ -7,13 +7,12 @@ import { CustomerCard } from './CustomerCard';
 
 La `CustomerCard` muestra de forma concisa la información principal de un cliente.
 Incluye foto o iniciales, nombre y datos secundarios como correo o teléfono.
-Opcionalmente se indica el nivel del cliente y un botón de acción.
+Opcionalmente se indica el nivel del cliente y un menú de acciones.
 
 <Canvas>
   <Story name="Ejemplos">
     <div className="w-72 space-y-2">
       <CustomerCard nombre="María Gómez" infoSecundaria="maria@gmail.com" nivel="VIP" />
-      <CustomerCard nombre="Pedro Ruiz" infoSecundaria="pedro@example.com" mostrarAccion />
       <CustomerCard
         nombre="Lucía Pérez"
         infoSecundaria="lucia@example.com"

--- a/frontend/src/molecules/CustomerCard/CustomerCard.stories.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.stories.tsx
@@ -14,10 +14,6 @@ const meta: Meta<CustomerCardProps> = {
       options: [undefined, 'VIP', 'Frecuente', 'Nuevo'],
     },
     mostrarAccion: { control: 'boolean' },
-    accionIntent: {
-      control: 'select',
-      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success'],
-    },
     accionIconName: { control: 'text' },
     actionOptions: { control: 'object' },
     onSelect: { action: 'selected' },
@@ -36,14 +32,6 @@ export const Default: Story = {
     infoSecundaria: 'maria@gmail.com',
     nivel: 'VIP',
     mostrarAccion: false,
-  },
-};
-
-export const ConAccion: Story = {
-  args: {
-    nombre: 'Pedro Ruiz',
-    infoSecundaria: 'pedro@example.com',
-    mostrarAccion: true,
   },
 };
 

--- a/frontend/src/molecules/CustomerCard/CustomerCard.test.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.test.tsx
@@ -23,13 +23,18 @@ describe('CustomerCard', () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onAction when action button clicked', () => {
+  it('calls onAction when action menu is opened', () => {
     const onAction = vi.fn();
     render(
-      <CustomerCard nombre="Ana" mostrarAccion onAction={onAction} />,
+      <CustomerCard
+        nombre="Ana"
+        mostrarAccion
+        actionOptions={[{ label: 'Edit', iconName: 'Edit' }]}
+        onAction={onAction}
+      />,
     );
-    const btn = screen.getByRole('button', { name: 'Ver detalles' });
-    fireEvent.click(btn);
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/molecules/CustomerCard/CustomerCard.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.tsx
@@ -4,7 +4,6 @@ import { Avatar } from '@/atoms/Avatar';
 import { Heading } from '@/atoms/Heading';
 import { Text } from '@/atoms/Text';
 import { Badge } from '@/atoms/Badge';
-import { Button } from '@/atoms/Button/Button';
 import { Icon, type IconName } from '@/atoms/Icon';
 import {
   ActionMenu,
@@ -32,8 +31,6 @@ export interface CustomerCardProps extends React.HTMLAttributes<HTMLDivElement> 
   nivel?: Nivel;
   /** Show action icon */
   mostrarAccion?: boolean;
-  /** Intent/color for the action button */
-  accionIntent?: React.ComponentProps<typeof Button>['intent'];
   /** Icon displayed inside the action button */
   accionIconName?: IconName;
   /** Options for an optional action menu */
@@ -54,7 +51,6 @@ export const CustomerCard = React.forwardRef<HTMLDivElement, CustomerCardProps>(
       infoSecundaria,
       nivel,
       mostrarAccion = false,
-      accionIntent = 'primary',
       accionIconName,
       actionOptions,
       actionMenuProps,
@@ -65,11 +61,6 @@ export const CustomerCard = React.forwardRef<HTMLDivElement, CustomerCardProps>(
     },
     ref,
   ) => {
-    const handleAction = (e: React.MouseEvent) => {
-      e.stopPropagation();
-      onAction?.();
-    };
-
     const clickable = typeof onSelect === 'function';
 
     return (
@@ -100,27 +91,15 @@ export const CustomerCard = React.forwardRef<HTMLDivElement, CustomerCardProps>(
             </Text>
           )}
         </div>
-        {mostrarAccion && (
-          actionOptions ? (
-            <ActionMenu
-              options={actionOptions}
-              onOpen={onAction}
-              position="bottom-right"
-              {...actionMenuProps}
-            >
-              <Icon name={accionIconName ?? 'MoreHorizontal'} />
-            </ActionMenu>
-          ) : (
-            <Button
-              variant="icon"
-              size="sm"
-              intent={accionIntent}
-              aria-label="Acciones"
-              onClick={handleAction}
-            >
-              <Icon name={accionIconName ?? 'ChevronRight'} />
-            </Button>
-          )
+        {mostrarAccion && Array.isArray(actionOptions) && actionOptions.length > 0 && (
+          <ActionMenu
+            options={actionOptions}
+            onOpen={onAction}
+            position="bottom-right"
+            {...actionMenuProps}
+          >
+            <Icon name={accionIconName ?? 'MoreHorizontal'} />
+          </ActionMenu>
         )}
       </Card>
     );


### PR DESCRIPTION
## Summary
- simplify CustomerCard and always use ActionMenu
- update docs and storybook example
- adjust tests for menu-only behaviour

## Testing
- `pnpm --filter erp_system exec vitest run src/molecules/CustomerCard`

------
https://chatgpt.com/codex/tasks/task_e_688043f6bbfc832b836da7e82e3f344c