### PR TITLE
Force NotificationIcon count text to black

### DIFF
--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
@@ -5,7 +5,7 @@ import { NotificationIcon } from './NotificationIcon';
 
 # NotificationIcon
 
-The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications. The count text inside the badge is always black for maximum contrast, and large counts are positioned to the right of the icon so they never cover it.
+The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications. The count text inside the badge is forced to black using `!text-black` for maximum contrast, and large counts are positioned to the right of the icon so they never cover it.
 
 <Canvas>
   <Story name="Examples">

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
@@ -27,7 +27,7 @@ describe('NotificationIcon', () => {
   it('badge text is black', () => {
     render(<NotificationIcon count={3} color="success" />);
     const badge = screen.getByText('3');
-    expect(badge).toHaveClass('text-black');
+    expect(badge).toHaveClass('!text-black');
   });
 
   it('positions badge outside icon for large counts', () => {

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.tsx
@@ -34,7 +34,7 @@ export const NotificationIcon = React.forwardRef<HTMLButtonElement, Notification
         {showBadge && (
           <Badge
             variant={color}
-            className="absolute -top-1 right-0 translate-x-1/2 rounded-full px-1 py-0 text-[10px] text-black"
+            className="absolute -top-1 right-0 translate-x-1/2 rounded-full px-1 py-0 text-[10px] !text-black"
           >
             {displayCount}
           </Badge>


### PR DESCRIPTION
## Summary
- make NotificationIcon badge use `!text-black` so the count is always black
- update tests and docs accordingly

## Testing
- `pnpm exec vitest run` *(fails: CustomerCard and DropdownMenu tests)*

------
https://chatgpt.com/codex/tasks/task_e_688044794578832ba2f0c2d9f1c3533a