### PR TITLE
Remove unused polyline sparkline from StatCard

### DIFF
--- a/frontend/src/molecules/StatCard/StatCard.docs.mdx
+++ b/frontend/src/molecules/StatCard/StatCard.docs.mdx
@@ -5,7 +5,7 @@ import { StatCard } from './StatCard';
 
 # StatCard
 
-The `StatCard` component highlights a single metric or KPI using the `Card` atom. It can optionally display an icon and be made clickable. The component also supports trend indicators, progress bars and a simple sparkline to visualise data.
+The `StatCard` component highlights a single metric or KPI using the `Card` atom. It can optionally display an icon and be made clickable. The component also supports trend indicators and progress bars.
 
 <Canvas>
   <Story name="Examples">
@@ -17,7 +17,6 @@ The `StatCard` component highlights a single metric or KPI using the `Card` atom
         progress={60}
         trend="up"
         trendValue="12%"
-        sparklineData={[10, 20, 15, 30, 25]}
       />
       <StatCard
         value="$5,000"
@@ -27,7 +26,6 @@ The `StatCard` component highlights a single metric or KPI using the `Card` atom
         trend="down"
         trendValue="-8%"
         progress={30}
-        sparklineData={[30, 25, 20, 15, 10]}
       />
     </div>
   </Story>

--- a/frontend/src/molecules/StatCard/StatCard.stories.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.stories.tsx
@@ -19,7 +19,6 @@ const meta: Meta<StatCardStoryProps> = {
     trend: { control: 'select', options: ['up', 'down'] },
     trendValue: { control: 'text' },
     progress: { control: 'number' },
-    sparklineData: { control: 'object' },
     variant: { control: 'select', options: ['shadow', 'outline', 'glass'] },
     clickable: { control: 'boolean' },
     onClick: { action: 'clicked', table: { category: 'Events' } },
@@ -40,7 +39,6 @@ export const Default: Story = {
     progress: 60,
     trend: 'up',
     trendValue: '12%',
-    sparklineData: [10, 20, 15, 30, 25],
   },
 };
 
@@ -53,6 +51,5 @@ export const Clickable: Story = {
     trend: 'down',
     trendValue: '-8%',
     progress: 30,
-    sparklineData: [30, 25, 20, 15, 10],
   },
 };

--- a/frontend/src/molecules/StatCard/StatCard.test.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.test.tsx
@@ -42,8 +42,8 @@ describe('StatCard', () => {
     expect(icon).toBeInTheDocument();
   });
 
-  it('renders sparkline when data supplied', () => {
-    const { container } = render(<StatCard value="5" label="Spark" sparklineData={[1,2,3]} />);
-    expect(container.querySelector('polyline')).toBeInTheDocument();
+  it('does not render a sparkline', () => {
+    const { container } = render(<StatCard value="5" label="Spark" />);
+    expect(container.querySelector('polyline')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/molecules/StatCard/StatCard.tsx
+++ b/frontend/src/molecules/StatCard/StatCard.tsx
@@ -34,8 +34,6 @@ export interface StatCardProps
   trendValue?: string | number;
   /** Progress percentage to visualize with a bar */
   progress?: number;
-  /** Data points for a small sparkline graph */
-  sparklineData?: number[];
 }
 
 export const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
@@ -47,7 +45,6 @@ export const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
       trend,
       trendValue,
       progress,
-      sparklineData,
       variant,
       clickable,
       orientation,
@@ -56,30 +53,6 @@ export const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
     },
     ref,
   ) => {
-    const renderSparkline = (data?: number[]) => {
-      if (!data || data.length < 2) return null;
-      const w = 64;
-      const h = 24;
-      const min = Math.min(...data);
-      const max = Math.max(...data);
-      const range = max - min || 1;
-      const points = data
-        .map((d, i) => {
-          const x = (i / (data.length - 1)) * w;
-          const y = h - ((d - min) / range) * h;
-          return `${x},${y}`;
-        })
-        .join(' ');
-      return (
-        <svg
-          viewBox={`0 0 ${w} ${h}`}
-          className="mt-2 h-6 w-full stroke-muted-foreground"
-          fill="none"
-        >
-          <polyline points={points} strokeWidth={1.5} />
-        </svg>
-      );
-    };
 
     return (
       <Card
@@ -119,7 +92,6 @@ export const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
         <Text as="span" className="text-sm text-muted-foreground">
           {label}
         </Text>
-        {renderSparkline(sparklineData)}
         {progress !== undefined && (
           <ProgressBar value={progress} size="sm" className="mt-2" />
         )}


### PR DESCRIPTION
## Summary
- drop sparkline logic from `StatCard`
- update storybook docs and stories
- adjust StatCard tests to reflect removal

## Testing
- `vitest` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_688046fab488832b9fa693b729a2b38e