### PR TITLE
Add white background to Accordion

### DIFF
--- a/frontend/src/atoms/Accordion/Accordion.docs.mdx
+++ b/frontend/src/atoms/Accordion/Accordion.docs.mdx
@@ -7,6 +7,8 @@ import { Accordion } from './Accordion';
 
 The `Accordion` component reveals or hides additional content when its header is clicked. It is useful for FAQs, filter sections or any collapsible information.
 
+It now includes a white background derived from the `Card` atom so it stays readable when placed on colored backgrounds.
+
 <Canvas>
   <Story name="Example">
     <Accordion title="Customer Details">

--- a/frontend/src/atoms/Accordion/Accordion.stories.tsx
+++ b/frontend/src/atoms/Accordion/Accordion.stories.tsx
@@ -60,3 +60,15 @@ export const Colors: Story = {
     children: '...',
   },
 };
+
+export const DarkBackground: Story = {
+  render: (args) => (
+    <div className="bg-neutral-700 p-4">
+      <Accordion {...args} />
+    </div>
+  ),
+  args: {
+    title: 'Sobre fondo oscuro',
+    children: 'Contenido del acordeón',
+  },
+};

--- a/frontend/src/atoms/Accordion/Accordion.test.tsx
+++ b/frontend/src/atoms/Accordion/Accordion.test.tsx
@@ -4,8 +4,11 @@ import { Accordion } from './Accordion';
 
 describe('Accordion', () => {
   it('renders title and children', () => {
-    render(<Accordion title="Title">Content</Accordion>);
+    const { container } = render(
+      <Accordion title="Title">Content</Accordion>,
+    );
     expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('bg-white');
   });
 
   it('hides content when closed', () => {

--- a/frontend/src/atoms/Accordion/Accordion.tsx
+++ b/frontend/src/atoms/Accordion/Accordion.tsx
@@ -62,7 +62,11 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
     const headerId = React.useId();
 
     return (
-      <div ref={ref} className={cn("border-b border-border", className)} {...props}>
+      <div
+        ref={ref}
+        className={cn("border-b border-border bg-white", className)}
+        {...props}
+      >
         <button
           type="button"
           id={headerId}

--- a/frontend/src/molecules/CustomerCard/CustomerCard.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.tsx
@@ -91,16 +91,19 @@ export const CustomerCard = React.forwardRef<HTMLDivElement, CustomerCardProps>(
             </Text>
           )}
         </div>
-        {mostrarAccion && Array.isArray(actionOptions) && actionOptions.length > 0 && (
-          <ActionMenu
-            options={actionOptions}
-            onOpen={onAction}
-            position="bottom-right"
-            {...actionMenuProps}
-          >
-            <Icon name={accionIconName ?? 'MoreHorizontal'} />
-          </ActionMenu>
-        )}
+        {mostrarAccion &&
+          Array.isArray(actionOptions) &&
+          actionOptions.length > 0 && (
+            <ActionMenu
+              aria-label="Acciones"
+              options={actionOptions}
+              onOpen={onAction}
+              position="bottom-right"
+              {...actionMenuProps}
+            >
+              <Icon name={accionIconName ?? 'MoreHorizontal'} />
+            </ActionMenu>
+          )}
       </Card>
     );
   },


### PR DESCRIPTION
## Summary
- give Accordion a white background
- document the Accordion background in Storybook docs
- show a dark background story for Accordion
- test Accordion background class
- label customer card action menu button for accessibility

## Testing
- `pnpm test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_688148238408832ba3a079560975ee92