### PR TITLE
Fix Modal stories and add focus test

### DIFF
--- a/frontend/src/atoms/Modal/Modal.stories.tsx
+++ b/frontend/src/atoms/Modal/Modal.stories.tsx
@@ -34,8 +34,16 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <Modal {...args} isOpen={open} onClose={() => setOpen(false)} />
+      </>
+    );
+  },
   args: {
-    isOpen: true,
     title: 'Simple Modal',
     children: 'Lorem ipsum dolor sit amet.',
   },
@@ -43,7 +51,7 @@ export const Default: Story = {
 
 export const WithActions: Story = {
   render: (args) => {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
     return (
       <>
         <Button onClick={() => setOpen(true)}>Open Modal</Button>
@@ -76,19 +84,22 @@ export const ColorVariants: Story = {
       'success',
       'destructive',
     ] as const;
+    const [open, setOpen] = useState<string | null>(null);
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {variants.map((v) => (
-          <Modal
-            key={v}
-            {...args}
-            isOpen
-            onClose={() => {}}
-            variant={v}
-            title={v.charAt(0).toUpperCase() + v.slice(1)}
-          >
-            {v} modal
-          </Modal>
+          <div key={v} className="flex flex-col items-start gap-2">
+            <Button onClick={() => setOpen(v)}>{`Open ${v}`}</Button>
+            <Modal
+              {...args}
+              isOpen={open === v}
+              onClose={() => setOpen(null)}
+              variant={v}
+              title={v.charAt(0).toUpperCase() + v.slice(1)}
+            >
+              {v} modal
+            </Modal>
+          </div>
         ))}
       </div>
     );

--- a/frontend/src/atoms/Modal/Modal.test.tsx
+++ b/frontend/src/atoms/Modal/Modal.test.tsx
@@ -62,4 +62,35 @@ describe('Modal', () => {
     await screen.findByRole('dialog');
     expect(screen.getByRole('dialog')).toHaveFocus();
   });
+
+  it('restores focus to trigger when closed', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <>
+        <button data-testid="trigger">open</button>
+        <Modal isOpen={false} onClose={onClose} title="Test Modal">
+          <p>content</p>
+        </Modal>
+      </>,
+    );
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    rerender(
+      <>
+        <button data-testid="trigger">open</button>
+        <Modal isOpen onClose={onClose} title="Test Modal">
+          <p>content</p>
+        </Modal>
+      </>,
+    );
+    rerender(
+      <>
+        <button data-testid="trigger">open</button>
+        <Modal isOpen={false} onClose={onClose} title="Test Modal">
+          <p>content</p>
+        </Modal>
+      </>,
+    );
+    expect(trigger).toHaveFocus();
+  });
 });


### PR DESCRIPTION
## Summary
- make Modal stories interactive so modals aren't open by default
- add regression test to ensure focus returns to trigger when closed

## Testing
- `npm test --prefix frontend -- --run src/atoms/Modal/Modal.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68814a100000832b8c6cfddf0f996cf1