### PR TITLE
Update ProgressBar label text color

### DIFF
--- a/frontend/src/atoms/ProgressBar/ProgressBar.docs.mdx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.docs.mdx
@@ -6,6 +6,7 @@ import { ProgressBar } from './ProgressBar';
 # ProgressBar
 
 Displays the progress of a task. Provide a `value` between 0 and 100 for determinate mode or omit the prop for an indeterminate bar. When a value is supplied the percentage is shown in a tag to the right of the bar.
+The value label text is always white regardless of the selected color.
 
 <Canvas>
   <Story name="Examples">

--- a/frontend/src/atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.stories.tsx
@@ -42,4 +42,11 @@ export const Colors: Story = {
     </div>
   ),
   args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: 'The value label text is always white regardless of the chosen color.',
+      },
+    },
+  },
 };

--- a/frontend/src/atoms/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.test.tsx
@@ -35,4 +35,16 @@ describe('ProgressBar', () => {
     render(<ProgressBar value={150} />);
     expect(screen.getByText('100%')).toBeInTheDocument();
   });
+
+  it('uses white text for the value label across colors', () => {
+    const { rerender } = render(
+      <ProgressBar color="primary" value={20} />,
+    );
+    let label = screen.getByText('20%');
+    expect(label.className).toContain('text-white');
+
+    rerender(<ProgressBar color="secondary" value={20} />);
+    label = screen.getByText('20%');
+    expect(label.className).toContain('text-white');
+  });
 });

--- a/frontend/src/atoms/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/atoms/ProgressBar/ProgressBar.tsx
@@ -32,20 +32,23 @@ const indicatorVariants = cva('h-full transition-[width] duration-300', {
   },
 });
 
-const labelVariants = cva('ml-2 px-2 py-0.5 text-xs font-medium rounded-full', {
-  variants: {
-    color: {
-      primary: 'bg-primary text-primary-foreground',
-      secondary: 'bg-secondary text-secondary-foreground',
-      tertiary: 'bg-tertiary text-tertiary-foreground',
-      quaternary: 'bg-quaternary text-quaternary-foreground',
-      success: 'bg-success text-success-foreground',
+const labelVariants = cva(
+  'ml-2 px-2 py-0.5 text-xs font-medium rounded-full text-white',
+  {
+    variants: {
+      color: {
+        primary: 'bg-primary',
+        secondary: 'bg-secondary',
+        tertiary: 'bg-tertiary',
+        quaternary: 'bg-quaternary',
+        success: 'bg-success',
+      },
+    },
+    defaultVariants: {
+      color: 'primary',
     },
   },
-  defaultVariants: {
-    color: 'primary',
-  },
-});
+);
 
 export interface ProgressBarProps
   extends React.HTMLAttributes<HTMLDivElement>,


### PR DESCRIPTION
## Summary
- ensure ProgressBar value label uses white text for every color
- update test to check white text
- document new behaviour in stories and docs

## Testing
- `npx vitest run src/atoms/ProgressBar/ProgressBar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68814a88f2c8832ba7e6628ca9d8b0f8