### PR TITLE
Add deselection behavior to Radio

### DIFF
--- a/frontend/src/atoms/Radio/Radio.docs.mdx
+++ b/frontend/src/atoms/Radio/Radio.docs.mdx
@@ -1,0 +1,29 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { Radio } from './Radio';
+
+<Meta title="Atoms/Radio" of={Radio} />
+
+# Radio
+
+El componente `Radio` permite seleccionar una sola opción de un conjunto.
+Cuando se usa de forma individual se puede activar la opción de deseleccionar
+estableciendo `allowDeselect` en `true`.
+
+<Canvas>
+  <Story name="Ejemplo">
+    {() => {
+      const [checked, setChecked] = React.useState(false);
+      return (
+        <Radio
+          allowDeselect
+          checked={checked}
+          onChange={(e) => setChecked(e.target.checked)}
+          label="Opción"
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Radio} />

--- a/frontend/src/atoms/Radio/Radio.stories.tsx
+++ b/frontend/src/atoms/Radio/Radio.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof Radio> = {
     disabled: { control: 'boolean' },
     label: { control: 'text' },
     name: { control: 'text' },
+    allowDeselect: { control: 'boolean' },
     onChange: { action: 'changed', table: { category: 'Events' } },
   },
 };
@@ -41,6 +42,7 @@ export const Default: Story = {
     label: 'Option',
     size: 'md',
     intent: 'primary',
+    allowDeselect: true,
   },
 };
 

--- a/frontend/src/atoms/Radio/Radio.test.tsx
+++ b/frontend/src/atoms/Radio/Radio.test.tsx
@@ -10,13 +10,15 @@ describe('Radio', () => {
     expect(radio).toHaveAttribute('name', 'group');
   });
 
-  it('toggles selection on click and triggers onChange', () => {
+  it('allows deselecting when allowDeselect is true', () => {
     const onChange = vi.fn();
-    render(<Radio name="group" label="Opt" onChange={onChange} />);
+    render(<Radio label="Opt" allowDeselect onChange={onChange} />);
     const radio = screen.getByRole('radio');
     fireEvent.click(radio);
     expect(radio).toBeChecked();
-    expect(onChange).toHaveBeenCalled();
+    fireEvent.click(radio);
+    expect(radio).not.toBeChecked();
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
   it('only one radio in group is selected', () => {

--- a/frontend/src/molecules/CustomerCard/CustomerCard.tsx
+++ b/frontend/src/molecules/CustomerCard/CustomerCard.tsx
@@ -96,6 +96,7 @@ export const CustomerCard = React.forwardRef<HTMLDivElement, CustomerCardProps>(
             options={actionOptions}
             onOpen={onAction}
             position="bottom-right"
+            aria-label="Acciones"
             {...actionMenuProps}
           >
             <Icon name={accionIconName ?? 'MoreHorizontal'} />


### PR DESCRIPTION
## Summary
- make Radio deselectable via `allowDeselect` prop
- document Radio usage in Storybook docs
- show deselect option in stories
- test deselection logic
- expose menu trigger label in `CustomerCard`

## Testing
- `npm test --silent -- --run src/atoms/Radio/Radio.test.tsx`
- `npm test --silent -- --run src/molecules/CustomerCard/CustomerCard.test.tsx`
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68814adf09f8832b9b8149c093b034a7