### PR TITLE
Update Table background

### DIFF
--- a/frontend/src/atoms/Table/Table.docs.mdx
+++ b/frontend/src/atoms/Table/Table.docs.mdx
@@ -5,7 +5,7 @@ import { Table } from './Table';
 
 # Table
 
-The `Table` component applies consistent styles to HTML tables. Use `variant`, `size`, and `color` props to control the appearance. It can also render data automatically via the `columns` and `data` props, support sortable headers, highlight rows on hover and become responsive with horizontal scrolling.
+The `Table` component applies consistent styles to HTML tables. Use `variant`, `size`, and `color` props to control the appearance. It can also render data automatically via the `columns` and `data` props, support sortable headers, highlight rows on hover and become responsive with horizontal scrolling. The table body always uses a white background so it remains readable on colored containers.
 
 <Canvas>
   <Story name="Example">
@@ -18,6 +18,20 @@ The `Table` component applies consistent styles to HTML tables. Use `variant`, `
       { producto: 'Pantalón', stock: 10, precio: 25 },
       { producto: 'Zapatos', stock: 5, precio: 50 }
     ]} hoverable />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Colored background">
+    <div className="bg-muted p-4">
+      <Table columns={[
+        { key: 'name', header: 'Name' },
+        { key: 'age', header: 'Age' }
+      ]} data={[
+        { name: 'Ana', age: 20 },
+        { name: 'Luis', age: 30 }
+      ]} />
+    </div>
   </Story>
 </Canvas>
 

--- a/frontend/src/atoms/Table/Table.stories.tsx
+++ b/frontend/src/atoms/Table/Table.stories.tsx
@@ -82,3 +82,17 @@ export const Responsive: Story = {
     ],
   },
 };
+
+export const OnColoredBackground: Story = {
+  args: {
+    caption: 'Table with white background',
+    columns,
+    data,
+    hoverable: true,
+  },
+  render: (args) => (
+    <div className="bg-muted p-4">
+      <Table {...args} />
+    </div>
+  ),
+};

--- a/frontend/src/atoms/Table/Table.test.tsx
+++ b/frontend/src/atoms/Table/Table.test.tsx
@@ -23,6 +23,12 @@ describe('Table', () => {
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
+  it('has a white background', () => {
+    render(basicTable);
+    const table = screen.getByRole('table');
+    expect(table.className).toContain('bg-white');
+  });
+
   it('applies striped variant classes', () => {
     render(
       <Table variant="striped">

--- a/frontend/src/atoms/Table/Table.tsx
+++ b/frontend/src/atoms/Table/Table.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react';
 
 const tableVariants = cva(
-  'w-full caption-bottom text-sm text-left border-collapse text-foreground [&_th]:border-b [&_th]:text-left [&_th]:font-semibold [&_th]:px-3 [&_td]:px-3 [&_td]:py-2 [&_th]:py-2 [&_td]:border-b [&_tr:last-child_>_td]:border-0',
+  'w-full caption-bottom text-sm text-left border-collapse text-foreground bg-white [&_th]:border-b [&_th]:text-left [&_th]:font-semibold [&_th]:px-3 [&_td]:px-3 [&_td]:py-2 [&_th]:py-2 [&_td]:border-b [&_tr:last-child_>_td]:border-0',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- ensure `Table` body always uses a white background
- show behaviour on coloured containers in Storybook
- document white background for tables
- add test for white background

## Testing
- `pnpm --filter erp_system exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814bbcab20832bab3cb816cffac7c7