### PR TITLE
Fix NotificationIcon badge text tests and docs

### DIFF
--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
@@ -5,7 +5,7 @@ import { NotificationIcon } from './NotificationIcon';
 
 # NotificationIcon
 
-The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications. The count text inside the badge is forced to black using `!text-black` for maximum contrast, and large counts are positioned to the right of the icon so they never cover it.
+The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications. The count text inside the badge is always black using `!text-black`, ensuring readability across all color variants. Large counts are positioned to the right of the icon so they never cover it.
 
 <Canvas>
   <Story name="Examples">
@@ -13,6 +13,18 @@ The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing
       <NotificationIcon count={0} />
       <NotificationIcon count={5} />
       <NotificationIcon count={120} />
+    </div>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Color variants">
+    <div className="flex space-x-2">
+      <NotificationIcon color="neutral" count={3} />
+      <NotificationIcon color="success" count={3} />
+      <NotificationIcon color="warning" count={3} />
+      <NotificationIcon color="destructive" count={3} />
+      <NotificationIcon color="info" count={3} />
     </div>
   </Story>
 </Canvas>

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.stories.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.stories.tsx
@@ -51,7 +51,7 @@ export const Many: Story = {
   },
 };
 
-export const Variants: Story = {
+export const ColorVariants: Story = {
   render: (args) => (
     <div className="flex space-x-2">
       <NotificationIcon {...args} color="neutral" count={5} />

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
@@ -24,10 +24,14 @@ describe('NotificationIcon', () => {
     expect(screen.getByText('99+')).toBeInTheDocument();
   });
 
-  it('badge text is black', () => {
-    render(<NotificationIcon count={3} color="success" />);
-    const badge = screen.getByText('3');
-    expect(badge).toHaveClass('!text-black');
+  it('badge text is black for all variants', () => {
+    const variants = ['neutral', 'success', 'warning', 'destructive', 'info'] as const;
+    variants.forEach((variant) => {
+      const { unmount } = render(<NotificationIcon count={3} color={variant} />);
+      const badge = screen.getByText('3');
+      expect(badge).toHaveClass('!text-black');
+      unmount();
+    });
   });
 
   it('positions badge outside icon for large counts', () => {


### PR DESCRIPTION
## Summary
- check badge text color for all NotificationIcon variants
- show color variants in storybook
- document that badge text stays black regardless of the variant

## Testing
- `pnpm test:frontend` *(fails: CustomerCard tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68814e3e77f4832ba803e49cb1a76dd1