### PR TITLE
Make PaginationControls interactive

### DIFF
--- a/frontend/src/molecules/PaginationControls/PaginationControls.docs.mdx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.docs.mdx
@@ -1,4 +1,5 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { useState } from 'react';
 import { PaginationControls } from './PaginationControls';
 
 <Meta title="Molecules/PaginationControls" of={PaginationControls} />
@@ -10,7 +11,16 @@ When the total number of pages exceeds five, intermediate pages collapse into an
 
 <Canvas>
   <Story name="Example">
-    <PaginationControls currentPage={3} totalPages={8} onPageChange={(page) => console.log(page)} />
+    {function ExampleStory() {
+      const [page, setPage] = useState(3);
+      return (
+        <PaginationControls
+          currentPage={page}
+          totalPages={8}
+          onPageChange={setPage}
+        />
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/frontend/src/molecules/PaginationControls/PaginationControls.stories.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 import { PaginationControls, PaginationControlsProps } from './PaginationControls';
 
 const meta: Meta<PaginationControlsProps> = {
@@ -24,6 +25,16 @@ export const Default: Story = {
     currentPage: 1,
     totalPages: 5,
   },
+  render: (args) => {
+    const [page, setPage] = useState(args.currentPage ?? 1);
+    return (
+      <PaginationControls
+        {...args}
+        currentPage={page}
+        onPageChange={setPage}
+      />
+    );
+  },
 };
 
 export const ManyPages: Story = {
@@ -32,5 +43,15 @@ export const ManyPages: Story = {
     totalPages: 8,
     siblings: 1,
     showFirstLast: true,
+  },
+  render: (args) => {
+    const [page, setPage] = useState(args.currentPage ?? 1);
+    return (
+      <PaginationControls
+        {...args}
+        currentPage={page}
+        onPageChange={setPage}
+      />
+    );
   },
 };

--- a/frontend/src/molecules/PaginationControls/PaginationControls.test.tsx
+++ b/frontend/src/molecules/PaginationControls/PaginationControls.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
 import { PaginationControls } from './PaginationControls';
 
 describe('PaginationControls', () => {
@@ -44,5 +45,23 @@ describe('PaginationControls', () => {
     const btn = screen.getByRole('button', { name: '1' });
     expect(btn.className).toMatch(/w-8/);
     expect(btn.className).toMatch(/h-8/);
+  });
+
+  it('updates page when controlled', () => {
+    const Wrapper = () => {
+      const [page, setPage] = useState(1);
+      return (
+        <PaginationControls
+          currentPage={page}
+          totalPages={3}
+          onPageChange={setPage}
+        />
+      );
+    };
+
+    render(<Wrapper />);
+    const page2 = screen.getByRole('button', { name: '2' });
+    fireEvent.click(page2);
+    expect(page2.getAttribute('aria-current')).toBe('page');
   });
 });


### PR DESCRIPTION
## Summary
- update PaginationControls stories to use state
- update PaginationControls docs with interactive example
- add test covering controlled behavior

## Testing
- `pnpm -F erp_system exec vitest run src/molecules/PaginationControls/PaginationControls.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688151ab96b4832b9d92a8955d3533df