### PR TITLE
Increase spacing between TagInput tags

### DIFF
--- a/frontend/src/molecules/TagInput/TagInput.docs.mdx
+++ b/frontend/src/molecules/TagInput/TagInput.docs.mdx
@@ -8,6 +8,8 @@ import { TagInput } from './TagInput';
 
 The `TagInput` component allows users to enter multiple tags in a single field. Each tag is displayed as a closable chip inside the input.
 
+Tags are now spaced slightly apart to improve readability.
+
 `tags` can be provided to set the initial list, but the component manages its own state. For a controlled usage combine `tags` and `onChange`.
 
 <Canvas>

--- a/frontend/src/molecules/TagInput/TagInput.stories.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.stories.tsx
@@ -6,6 +6,14 @@ const meta: Meta<TagInputProps> = {
   title: 'Molecules/TagInput',
   component: TagInput,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Las etiquetas ahora cuentan con un pequeño espacio entre ellas para mejorar la lectura.',
+      },
+    },
+  },
   argTypes: {
     tags: { control: 'object' },
     placeholder: { control: 'text' },

--- a/frontend/src/molecules/TagInput/TagInput.test.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.test.tsx
@@ -49,4 +49,10 @@ describe('TagInput', () => {
     fireEvent.keyDown(input, { key: 'Backspace' });
     expect(screen.queryByText('last')).not.toBeInTheDocument();
   });
+
+  it('has spacing between tag items', () => {
+    render(<TagInput tags={['a', 'b']} />);
+    const container = screen.getByRole('textbox').parentElement as HTMLElement;
+    expect(container).toHaveClass('gap-2');
+  });
 });

--- a/frontend/src/molecules/TagInput/TagInput.tsx
+++ b/frontend/src/molecules/TagInput/TagInput.tsx
@@ -102,7 +102,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
     return (
       <div
         className={cn(
-          'flex flex-wrap items-center gap-1 cursor-text',
+          'flex flex-wrap items-center gap-2 cursor-text',
           inputVariants({ size, color }),
           disabled && 'opacity-50 cursor-not-allowed',
           className,


### PR DESCRIPTION
## Summary
- add gap between TagInput tags
- test for new spacing
- document TagInput spacing in docs and storybook

## Testing
- `pnpm exec vitest run` *(fails: CustomerCard.test.tsx)*
- `pnpm exec vitest run src/molecules/TagInput/TagInput.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688158e4f71c832bb18990dffe8cc2b5