### PR TITLE
Add FormField molecule

### DIFF
--- a/frontend/src/molecules/FormField/FormField.docs.mdx
+++ b/frontend/src/molecules/FormField/FormField.docs.mdx
@@ -1,0 +1,40 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { FormField } from './FormField';
+import { Input } from '@/atoms/Input';
+import { Textarea } from '@/atoms/Textarea';
+
+<Meta title="Molecules/FormField" of={FormField} />
+
+# FormField
+
+The `FormField` component groups a label, a form control and a helper or error
+message. It keeps spacing and accessibility attributes consistent, making it
+ideal for libraries like React Hook Form or Formik.
+
+<Canvas>
+  <Story name="Uncontrolled">
+    <FormField id="email" label="Email" helperText="We\'ll never share it">
+      <Input type="email" />
+    </FormField>
+  </Story>
+  <Story name="Controlled">
+    {() => {
+      const [value, setValue] = React.useState('');
+      return (
+        <FormField id="name" label="Name">
+          <Input value={value} onChange={(e) => setValue(e.target.value)} />
+        </FormField>
+      );
+    }}
+  </Story>
+  <Story name="Slot pattern">
+    {() => (
+      <FormField id="about" label="About you">
+        <Textarea />
+      </FormField>
+    )}
+  </Story>
+</Canvas>
+
+<ArgsTable of={FormField} />

--- a/frontend/src/molecules/FormField/FormField.stories.tsx
+++ b/frontend/src/molecules/FormField/FormField.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { FormField, FormFieldProps } from './FormField';
+import { Input } from '@/atoms/Input';
+import { Textarea } from '@/atoms/Textarea';
+
+const meta: Meta<FormFieldProps> = {
+  title: 'Molecules/FormField',
+  component: FormField,
+  tags: ['autodocs'],
+  argTypes: {
+    id: { control: 'text' },
+    label: { control: 'text' },
+    required: { control: 'boolean' },
+    helperText: { control: 'text' },
+    error: { control: 'text' },
+    children: { table: { disable: true } },
+  },
+  render: (args) => <FormField {...args}>{args.children ?? <Input />}</FormField>,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    id: 'name',
+    label: 'Name',
+    helperText: 'Enter your name',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    id: 'email',
+    label: 'Email',
+    error: 'Required field',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    id: 'username',
+    label: 'Username',
+    required: true,
+  },
+};
+
+export const WithTextarea: Story = {
+  args: {
+    id: 'about',
+    label: 'About you',
+    helperText: 'Tell us about yourself',
+    children: <Textarea />,
+  },
+};

--- a/frontend/src/molecules/FormField/FormField.test.tsx
+++ b/frontend/src/molecules/FormField/FormField.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FormField } from './FormField';
+import { Input } from '@/atoms/Input';
+
+describe('FormField', () => {
+  it('renders label and helper', () => {
+    render(
+      <FormField id="name" label="Name" helperText="help">
+        <Input />
+      </FormField>,
+    );
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByText('help')).toBeInTheDocument();
+  });
+
+  it('shows error when set', () => {
+    const { rerender } = render(
+      <FormField id="name" label="Name" helperText="help">
+        <Input />
+      </FormField>,
+    );
+    const input = screen.getByLabelText('Name');
+    fireEvent.blur(input);
+    rerender(
+      <FormField id="name" label="Name" error="required">
+        <Input />
+      </FormField>,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('required');
+  });
+
+  it('associates label with control', () => {
+    render(
+      <FormField id="email" label="Email">
+        <Input />
+      </FormField>,
+    );
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/molecules/FormField/FormField.tsx
+++ b/frontend/src/molecules/FormField/FormField.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface FormControlProps {
+  id?: string;
+  required?: boolean;
+  'aria-required'?: boolean;
+  'aria-invalid'?: boolean;
+  'aria-describedby'?: string;
+  onFocus?: React.FocusEventHandler<any>;
+  onBlur?: React.FocusEventHandler<any>;
+}
+
+export interface FormFieldProps
+  extends React.HTMLAttributes<HTMLFieldSetElement> {
+  id: string;
+  label: React.ReactNode;
+  required?: boolean;
+  helperText?: string;
+  error?: string;
+  children: React.ReactElement<FormControlProps>;
+}
+
+export const FormField = React.forwardRef<HTMLFieldSetElement, FormFieldProps>(
+  (
+    {
+      id,
+      label,
+      required = false,
+      helperText,
+      error,
+      children,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const [focused, setFocused] = React.useState(false);
+    const messageId = helperText || error ? `${id}-message` : undefined;
+
+    const handleFocus: React.FocusEventHandler<any> = (e) => {
+      setFocused(true);
+      children.props.onFocus?.(e);
+    };
+
+    const handleBlur: React.FocusEventHandler<any> = (e) => {
+      setFocused(false);
+      children.props.onBlur?.(e);
+    };
+
+    const control = React.cloneElement(children, {
+      id,
+      required,
+      'aria-required': required || undefined,
+      'aria-invalid': error ? true : children.props['aria-invalid'],
+      'aria-describedby': messageId,
+      onFocus: handleFocus,
+      onBlur: handleBlur,
+    });
+
+    return (
+      <fieldset
+        ref={ref}
+        data-focused={focused || undefined}
+        className={cn('form-field space-y-1', className)}
+        {...props}
+      >
+        <label htmlFor={id} className="form-field__label block text-sm font-medium">
+          {label}
+          {required && (
+            <span aria-hidden="true" className="text-destructive ml-1">
+              *
+            </span>
+          )}
+        </label>
+        <div className="form-field__control">{control}</div>
+        {(helperText || error) && (
+          <p
+            id={messageId}
+            role={error ? 'alert' : undefined}
+            className={cn(
+              'form-field__message text-sm',
+              error ? 'text-destructive' : 'text-muted-foreground',
+            )}
+          >
+            {error ?? helperText}
+          </p>
+        )}
+      </fieldset>
+    );
+  },
+);
+FormField.displayName = 'FormField';
+
+export type { FormControlProps };

--- a/frontend/src/molecules/FormField/index.ts
+++ b/frontend/src/molecules/FormField/index.ts
@@ -1,0 +1,1 @@
+export * from './FormField';


### PR DESCRIPTION
## Summary
- add `FormField` molecule to group label, control and messages
- document usage with Storybook docs
- provide Storybook stories for common states
- include unit tests for FormField

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68817f5cd6dc832b81f29a933aa0114b