### PR TITLE
Add SearchBar molecule

### DIFF
--- a/frontend/src/molecules/SearchBar/SearchBar.docs.mdx
+++ b/frontend/src/molecules/SearchBar/SearchBar.docs.mdx
@@ -1,0 +1,33 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { SearchBar } from './SearchBar';
+
+<Meta title="Molecules/SearchBar" of={SearchBar} />
+
+# SearchBar
+
+Compact search field with optional button. Supports debounce when typing.
+
+<Canvas>
+  <Story name="Ejemplo controlado">
+    {() => {
+      const [term, setTerm] = React.useState('');
+      return (
+        <SearchBar
+          value={term}
+          onSearch={setTerm}
+          showButton
+          placeholder="Buscar..."
+        />
+      );
+    }}
+  </Story>
+  <Story name="Sin botón">
+    {() => <SearchBar placeholder="Buscar..." onSearch={() => {}} />}
+  </Story>
+  <Story name="Debounce live">
+    {() => <SearchBar placeholder="Buscar..." debounce={500} onSearch={() => {}} />}
+  </Story>
+</Canvas>
+
+<ArgsTable of={SearchBar} />

--- a/frontend/src/molecules/SearchBar/SearchBar.stories.tsx
+++ b/frontend/src/molecules/SearchBar/SearchBar.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { SearchBar, SearchBarProps } from './SearchBar';
+
+const meta: Meta<SearchBarProps> = {
+  title: 'Molecules/SearchBar',
+  component: SearchBar,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: 'text', name: 'valor' },
+    placeholder: { control: 'text' },
+    showButton: { control: 'boolean' },
+    debounce: { control: 'number' },
+    onSearch: { action: 'search', table: { category: 'Events' } },
+  },
+  render: (args) => {
+    const [term, setTerm] = React.useState(args.value ?? '');
+    return (
+      <SearchBar
+        {...args}
+        value={term}
+        onSearch={(t) => {
+          args.onSearch?.(t);
+          setTerm(t);
+        }}
+      />
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { placeholder: 'Buscar...' },
+};
+
+export const WithButton: Story = {
+  args: { placeholder: 'Buscar...', showButton: true },
+};
+
+export const Debounced: Story = {
+  args: { placeholder: 'Buscar...', debounce: 500 },
+};

--- a/frontend/src/molecules/SearchBar/SearchBar.test.tsx
+++ b/frontend/src/molecules/SearchBar/SearchBar.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SearchBar } from './SearchBar';
+
+describe('SearchBar', () => {
+  it('calls onSearch on Enter', () => {
+    const onSearch = vi.fn();
+    render(<SearchBar onSearch={onSearch} />);
+    const input = screen.getByRole('searchbox');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.submit(screen.getByRole('search'));
+    expect(onSearch).toHaveBeenCalledWith('hello');
+  });
+
+  it('debounces search calls', () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn();
+    render(<SearchBar onSearch={onSearch} debounce={300} />);
+    const input = screen.getByRole('searchbox');
+    fireEvent.change(input, { target: { value: 'h' } });
+    vi.advanceTimersByTime(100);
+    fireEvent.change(input, { target: { value: 'he' } });
+    vi.advanceTimersByTime(299);
+    expect(onSearch).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onSearch).toHaveBeenCalledWith('he');
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/molecules/SearchBar/SearchBar.tsx
+++ b/frontend/src/molecules/SearchBar/SearchBar.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { Input } from '@/atoms/Input';
+import { Button } from '@/atoms/Button';
+import { Icon } from '@/atoms/Icon';
+
+export interface SearchBarProps extends React.FormHTMLAttributes<HTMLFormElement> {
+  /** Current search term (controlled or initial value) */
+  value?: string;
+  /** Placeholder text for the input */
+  placeholder?: string;
+  /** Show submit button */
+  showButton?: boolean;
+  /** Called when a search is triggered */
+  onSearch(term: string): void;
+  /** Debounce time in ms before calling onSearch on typing */
+  debounce?: number;
+  /** Accessible label for the search form */
+  ariaLabel?: string;
+}
+
+export const SearchBar = React.forwardRef<HTMLFormElement, SearchBarProps>(
+  (
+    {
+      value,
+      placeholder = 'Buscar...',
+      showButton = false,
+      onSearch,
+      debounce = 0,
+      ariaLabel = 'Buscar',
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const [term, setTerm] = React.useState(value ?? '');
+    const timeoutRef = React.useRef<number>();
+
+    React.useEffect(() => {
+      if (value !== undefined) setTerm(value);
+    }, [value]);
+
+    const emitSearch = React.useCallback(
+      (t: string) => {
+        onSearch(t);
+      },
+      [onSearch],
+    );
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      const val = e.target.value;
+      if (value === undefined) setTerm(val);
+      else setTerm(val);
+
+      if (debounce > 0) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = window.setTimeout(() => emitSearch(val), debounce);
+      }
+    };
+
+    const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+      e.preventDefault();
+      window.clearTimeout(timeoutRef.current);
+      emitSearch(term);
+    };
+
+    const SearchIcon = ({ className, size }: { className?: string; size?: number }) => (
+      <Icon name="Search" className={className} size={size} aria-hidden="true" />
+    );
+
+    return (
+      <form
+        role="search"
+        aria-label={ariaLabel}
+        ref={ref}
+        onSubmit={handleSubmit}
+        className={cn('search-bar flex items-center gap-2', className)}
+        {...props}
+      >
+        <Input
+          type="search"
+          placeholder={placeholder}
+          value={term}
+          onChange={handleChange}
+          LeftIcon={SearchIcon}
+        />
+        {showButton && (
+          <Button type="submit" size="sm">
+            Buscar
+          </Button>
+        )}
+      </form>
+    );
+  },
+);
+SearchBar.displayName = 'SearchBar';
+
+export default SearchBar;

--- a/frontend/src/molecules/SearchBar/index.ts
+++ b/frontend/src/molecules/SearchBar/index.ts
@@ -1,0 +1,1 @@
+export * from './SearchBar';


### PR DESCRIPTION
## Summary
- add SearchBar molecule with optional button and debounce
- document SearchBar with Storybook docs and stories
- test SearchBar behaviour

## Testing
- `npm run test:frontend`

------
https://chatgpt.com/codex/tasks/task_e_68818d6755b8832bb384a5716ec4d6bc