### PR TITLE
Add ConfirmationDialog molecule

### DIFF
--- a/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.docs.mdx
+++ b/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.docs.mdx
@@ -1,0 +1,86 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { ConfirmationDialog } from './ConfirmationDialog';
+import { Button } from '@/atoms/Button/Button';
+
+<Meta title="Molecules/ConfirmationDialog" of={ConfirmationDialog} />
+
+# ConfirmationDialog
+
+El `ConfirmationDialog` muestra un mensaje de confirmación dentro de un modal con acciones para confirmar o cancelar.
+
+## Ejemplo básico
+
+<Canvas>
+  <Story name="Ejemplo">
+    {() => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <Button onClick={() => setOpen(true)}>Eliminar</Button>
+          <ConfirmationDialog
+            isOpen={open}
+            title="Eliminar elemento"
+            message="¿Seguro que deseas continuar?"
+            onConfirm={() => setOpen(false)}
+            onCancel={() => setOpen(false)}
+          />
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Estado danger
+
+<Canvas>
+  <Story name="Danger">
+    {() => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <Button intent="tertiary" onClick={() => setOpen(true)}>
+            Eliminar
+          </Button>
+          <ConfirmationDialog
+            isOpen={open}
+            title="Eliminar registro"
+            message="Esta acción no se puede deshacer."
+            danger
+            onConfirm={() => setOpen(false)}
+            onCancel={() => setOpen(false)}
+          />
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Uso programático
+
+<Canvas>
+  <Story name="Programático">
+    {function Example() {
+      const [open, setOpen] = React.useState(false);
+      const handleDelete = () => setOpen(true);
+      const handleConfirm = () => {
+        setOpen(false);
+        // Realizar acción
+      };
+      return (
+        <>
+          <Button onClick={handleDelete}>Borrar</Button>
+          <ConfirmationDialog
+            isOpen={open}
+            title="Confirmar"
+            message="¿Desea continuar?"
+            onConfirm={handleConfirm}
+            onCancel={() => setOpen(false)}
+          />
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={ConfirmationDialog} />

--- a/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.stories.tsx
+++ b/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { ConfirmationDialog, type ConfirmationDialogProps } from './ConfirmationDialog';
+import { Button } from '@/atoms/Button/Button';
+
+const meta: Meta<ConfirmationDialogProps> = {
+  title: 'Molecules/ConfirmationDialog',
+  component: ConfirmationDialog,
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    title: { control: 'text' },
+    message: { control: 'text' },
+    confirmLabel: { control: 'text' },
+    cancelLabel: { control: 'text' },
+    danger: { control: 'boolean' },
+    onConfirm: { action: 'confirm', table: { category: 'Events' } },
+    onCancel: { action: 'cancel', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Eliminar elemento',
+    message: '¿Estás seguro de que deseas continuar?',
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Abrir</Button>
+        <ConfirmationDialog
+          {...args}
+          isOpen={open}
+          onConfirm={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    title: 'Eliminar registro',
+    message: 'Esta acción no se puede deshacer. ¿Desea continuar?',
+    danger: true,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button intent="tertiary" onClick={() => setOpen(true)}>
+          Abrir
+        </Button>
+        <ConfirmationDialog
+          {...args}
+          isOpen={open}
+          onConfirm={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const LongMessage: Story = {
+  args: {
+    title: 'Términos y condiciones',
+    message:
+      'Este es un mensaje largo para verificar que el diálogo se adapte correctamente al contenido. '.repeat(3),
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Abrir</Button>
+        <ConfirmationDialog
+          {...args}
+          isOpen={open}
+          onConfirm={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};

--- a/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConfirmationDialog } from './ConfirmationDialog';
+
+const renderDialog = (
+  props: Partial<React.ComponentProps<typeof ConfirmationDialog>> = {},
+) =>
+  render(
+    <ConfirmationDialog
+      isOpen
+      title="Confirmar"
+      message="¿Seguro?"
+      onConfirm={() => {}}
+      onCancel={() => {}}
+      {...props}
+    />,
+  );
+
+describe('ConfirmationDialog', () => {
+  it('calls onConfirm and onCancel', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    renderDialog({ onConfirm, onCancel });
+    fireEvent.click(screen.getByText('Cancelar'));
+    expect(onCancel).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Confirmar'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('backdrop click closes', () => {
+    const onCancel = vi.fn();
+    renderDialog({ onCancel });
+    const backdrop = screen.getByRole('alertdialog').previousSibling as Element;
+    fireEvent.click(backdrop);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('cycles focus within the dialog', () => {
+    renderDialog();
+    const cancelButton = screen.getByText('Cancelar');
+    const confirmButton = screen.getByText('Confirmar');
+    cancelButton.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(confirmButton);
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(cancelButton);
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(confirmButton);
+  });
+});

--- a/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/frontend/src/molecules/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/atoms/Button/Button';
+import { modalVariants } from '@/atoms/Modal';
+import { cn } from '@/lib/utils';
+
+export interface ConfirmationDialogProps {
+  /** Controls visibility of the dialog */
+  isOpen: boolean;
+  /** Heading text */
+  title: string;
+  /** Description or message */
+  message: React.ReactNode;
+  /** Label for the confirm button */
+  confirmLabel?: string;
+  /** Label for the cancel button */
+  cancelLabel?: string;
+  /** Called when user confirms */
+  onConfirm: () => void;
+  /** Called when user cancels */
+  onCancel: () => void;
+  /** Show warning style */
+  danger?: boolean;
+}
+
+export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
+  isOpen,
+  title,
+  message,
+  confirmLabel = 'Confirmar',
+  cancelLabel = 'Cancelar',
+  onConfirm,
+  onCancel,
+  danger = false,
+}) => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const cancelButtonRef = React.useRef<HTMLButtonElement>(null);
+  const lastFocused = React.useRef<Element | null>(null);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    lastFocused.current = document.activeElement;
+    const container = containerRef.current;
+    // focus cancel button initially
+    setTimeout(() => cancelButtonRef.current?.focus(), 0);
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      } else if (e.key === 'Tab') {
+        const focusable = container?.querySelectorAll<HTMLElement>(
+          'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])',
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      (lastFocused.current as HTMLElement | null)?.focus?.();
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        aria-hidden="true"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCancel();
+        }}
+      />
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby="confirm-dialog-message"
+        className={cn(modalVariants({ variant: 'default', size: 'md' }))}
+        ref={containerRef}
+        tabIndex={-1}
+      >
+        <h2 id="confirm-dialog-title" className="text-lg font-semibold mb-2">
+          {title}
+        </h2>
+        <div id="confirm-dialog-message" className="mb-4 flex items-start gap-2">
+          {danger && (
+            <AlertTriangle
+              className="mt-0.5 text-destructive flex-shrink-0"
+              size={20}
+              aria-hidden="true"
+            />
+          )}
+          <div className="flex-1 text-sm">{message}</div>
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button
+            variant="outline"
+            intent="secondary"
+            onClick={onCancel}
+            ref={cancelButtonRef}
+          >
+            {cancelLabel}
+          </Button>
+          <Button intent={danger ? 'tertiary' : 'primary'} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+ConfirmationDialog.displayName = 'ConfirmationDialog';

--- a/frontend/src/molecules/ConfirmationDialog/index.ts
+++ b/frontend/src/molecules/ConfirmationDialog/index.ts
@@ -1,0 +1,1 @@
+export * from './ConfirmationDialog';


### PR DESCRIPTION
## Summary
- add ConfirmationDialog component with alert dialog behaviour
- document ConfirmationDialog usage and variants
- add Storybook stories
- include basic tests

## Testing
- `pnpm --filter erp_system exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818e9efca0832b8b1875c987646f1a