### PR TITLE
Add PageHeader molecule

### DIFF
--- a/frontend/src/molecules/PageHeader/PageHeader.docs.mdx
+++ b/frontend/src/molecules/PageHeader/PageHeader.docs.mdx
@@ -1,0 +1,41 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { PageHeader } from './PageHeader';
+import { Button } from '@/atoms/Button';
+
+<Meta title="Molecules/PageHeader" of={PageHeader} />
+
+# PageHeader
+
+The `PageHeader` component displays breadcrumbs, a main title and
+an area for secondary actions. It adjusts actions below the title on
+small screens and can optionally show a divider.
+
+<Canvas>
+  <Story name="Structure">
+    <PageHeader
+      title="Products"
+      breadcrumbs={[{ label: 'Home', href: '#' }, { label: 'Catalog', href: '#' }, { label: 'Products' }]}
+      actions={<Button intent="secondary">New</Button>}
+      icon="Folder"
+      divider
+    />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Many actions">
+    <PageHeader
+      title="Orders"
+      breadcrumbs={[{ label: 'Home', href: '#' }, { label: 'Orders' }]}
+      actions={
+        <div className="flex gap-2 flex-wrap">
+          <Button intent="secondary">Export</Button>
+          <Button intent="secondary">Filter</Button>
+          <Button intent="secondary">New</Button>
+        </div>
+      }
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={PageHeader} />

--- a/frontend/src/molecules/PageHeader/PageHeader.stories.tsx
+++ b/frontend/src/molecules/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PageHeader, type PageHeaderProps } from './PageHeader';
+import { Button } from '@/atoms/Button';
+
+const meta: Meta<PageHeaderProps> = {
+  title: 'Molecules/PageHeader',
+  component: PageHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    breadcrumbs: { control: 'object' },
+    actions: { control: 'object' },
+    icon: { control: 'text' },
+    divider: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const baseCrumbs = [
+  { label: 'Home', href: '#' },
+  { label: 'Products', href: '#' },
+  { label: 'Item' },
+];
+
+export const Default: Story = {
+  args: {
+    title: 'Products',
+    breadcrumbs: baseCrumbs,
+    divider: true,
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: 'Orders',
+    breadcrumbs: [{ label: 'Home', href: '#' }, { label: 'Orders' }],
+    actions: (
+      <div className="flex gap-2 flex-wrap">
+        <Button intent="secondary">Export</Button>
+        <Button intent="secondary">New</Button>
+      </div>
+    ),
+  },
+};
+
+export const MobileCollapse: Story = {
+  args: {
+    title: 'Mobile view',
+    breadcrumbs: [{ label: 'Home', href: '#' }, { label: 'Mobile' }],
+    actions: (
+      <div className="flex gap-2 flex-wrap">
+        <Button intent="secondary">Export</Button>
+        <Button intent="secondary">Filter</Button>
+        <Button intent="secondary">New</Button>
+      </div>
+    ),
+  },
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};

--- a/frontend/src/molecules/PageHeader/PageHeader.test.tsx
+++ b/frontend/src/molecules/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PageHeader } from './PageHeader';
+import { Button } from '@/atoms/Button';
+
+const breadcrumbs = [
+  { label: 'Home', href: '#' },
+  { label: 'Products' },
+];
+
+describe('PageHeader', () => {
+  it('renders breadcrumbs and title', () => {
+    render(<PageHeader title="Products" breadcrumbs={breadcrumbs} />);
+    expect(screen.getByRole('heading', { name: 'Products' })).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument();
+  });
+
+  it('renders actions', () => {
+    render(
+      <PageHeader
+        title="Products"
+        breadcrumbs={breadcrumbs}
+        actions={<Button>New</Button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument();
+  });
+
+  it('matches mobile snapshot', () => {
+    const { asFragment } = render(
+      <PageHeader
+        title="Mobile"
+        breadcrumbs={breadcrumbs}
+        actions={<Button>New</Button>}
+      />,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/molecules/PageHeader/PageHeader.tsx
+++ b/frontend/src/molecules/PageHeader/PageHeader.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { Breadcrumbs, type BreadcrumbItem } from '@/atoms/Breadcrumbs';
+import { Heading } from '@/atoms/Heading';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { Divider } from '@/atoms/Divider';
+
+export interface PageHeaderProps extends React.HTMLAttributes<HTMLElement> {
+  /** Main title content */
+  title: React.ReactNode;
+  /** Breadcrumb navigation items */
+  breadcrumbs?: BreadcrumbItem[];
+  /** Secondary action elements */
+  actions?: React.ReactNode;
+  /** Optional icon to show next to title */
+  icon?: IconName;
+  /** Render divider below header */
+  divider?: boolean;
+}
+
+export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
+  (
+    { title, breadcrumbs, actions, icon, divider = false, className, ...props },
+    ref,
+  ) => {
+    return (
+      <header
+        ref={ref}
+        className={cn('page-header space-y-2', className)}
+        {...props}
+      >
+        {breadcrumbs && breadcrumbs.length > 0 && (
+          <Breadcrumbs items={breadcrumbs} className="mb-1" />
+        )}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="title-group flex items-center gap-2">
+            {icon && <Icon name={icon} className="h-6 w-6 text-muted-foreground" aria-hidden="true" />}
+            <Heading level={2}>{title}</Heading>
+          </div>
+          {actions && <div className="actions flex flex-wrap items-center gap-2">{actions}</div>}
+        </div>
+        {divider && <Divider className="mt-2" />}
+      </header>
+    );
+  },
+);
+PageHeader.displayName = 'PageHeader';
+
+export default PageHeader;

--- a/frontend/src/molecules/PageHeader/__snapshots__/PageHeader.test.tsx.snap
+++ b/frontend/src/molecules/PageHeader/__snapshots__/PageHeader.test.tsx.snap
@@ -1,0 +1,67 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PageHeader > matches mobile snapshot 1`] = `
+<DocumentFragment>
+  <header
+    class="page-header space-y-2"
+  >
+    <nav
+      aria-label="Breadcrumb"
+      class="text-sm mb-1"
+    >
+      <ol
+        class="flex flex-wrap items-center"
+      >
+        <li
+          class="flex items-center"
+        >
+          <a
+            class="text-sm font-medium underline underline-offset-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ring-offset-background text-secondary hover:text-secondary/80 whitespace-nowrap"
+            href="#"
+            style="text-decoration: underline;"
+          >
+            Home
+          </a>
+          <span
+            class="mx-2 text-muted-foreground"
+          >
+            /
+          </span>
+        </li>
+        <li
+          class="flex items-center"
+        >
+          <span
+            aria-current="page"
+            class="font-medium text-foreground whitespace-nowrap"
+          >
+            Products
+          </span>
+        </li>
+      </ol>
+    </nav>
+    <div
+      class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div
+        class="title-group flex items-center gap-2"
+      >
+        <h2
+          class="font-heading text-4xl font-medium tracking-tight text-left text-primary"
+        >
+          Mobile
+        </h2>
+      </div>
+      <div
+        class="actions flex flex-wrap items-center gap-2"
+      >
+        <button
+          class="group inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-secondary disabled:pointer-events-none disabled:opacity-50 hover:-translate-y-px hover:shadow-sm active:translate-y-0 active:shadow-md active:scale-105 border-transparent text-primary-foreground h-10 bg-gradient-to-br from-primary to-primary/90 hover:from-primary/90 hover:to-primary/80 px-6 min-w-[10rem]"
+        >
+          New
+        </button>
+      </div>
+    </div>
+  </header>
+</DocumentFragment>
+`;

--- a/frontend/src/molecules/PageHeader/index.ts
+++ b/frontend/src/molecules/PageHeader/index.ts
@@ -1,0 +1,1 @@
+export * from './PageHeader';


### PR DESCRIPTION
## Summary
- add PageHeader component with optional breadcrumbs, actions, icon and divider
- document PageHeader in Storybook and provide examples
- add stories including mobile collapse variant
- create tests and snapshot for PageHeader

## Testing
- `pnpm --filter erp_system exec vitest run src/molecules/PageHeader/PageHeader.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6883da9e1e1c832bb5cc33b0fd417313