### PR TITLE
Add NotificationList molecule

### DIFF
--- a/frontend/src/molecules/NotificationList/NotificationList.docs.mdx
+++ b/frontend/src/molecules/NotificationList/NotificationList.docs.mdx
@@ -1,0 +1,37 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { NotificationList } from './NotificationList';
+
+<Meta title="Molecules/NotificationList" of={NotificationList} />
+
+# NotificationList
+
+The `NotificationList` component displays a list of user notifications. Items are ordered by date and clicking an item marks it as read.
+
+<Canvas>
+  <Story name="Examples">
+    {() => (
+      <NotificationList
+        notifications={[
+          {
+            id: '1',
+            title: 'Nuevo pedido',
+            message: 'Se ha creado el pedido #101',
+            date: new Date('2025-06-01T12:00:00'),
+            read: false,
+            type: 'info',
+          },
+          {
+            id: '2',
+            title: 'Envío completado',
+            message: 'El pedido #100 fue entregado',
+            date: new Date('2025-05-30T08:30:00'),
+            read: true,
+            type: 'success',
+          },
+        ]}
+      />
+    )}
+  </Story>
+</Canvas>
+
+<ArgsTable of={NotificationList} />

--- a/frontend/src/molecules/NotificationList/NotificationList.stories.tsx
+++ b/frontend/src/molecules/NotificationList/NotificationList.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NotificationList, NotificationListProps, Notification } from './NotificationList';
+
+const baseNotifications: Notification[] = [
+  {
+    id: '1',
+    title: 'Bienvenido',
+    message: 'Gracias por registrarte',
+    date: new Date('2025-06-01T10:00:00'),
+    read: false,
+    type: 'info',
+  },
+  {
+    id: '2',
+    title: 'Pedido entregado',
+    message: 'Tu pedido #123 fue entregado',
+    date: new Date('2025-06-02T12:00:00'),
+    read: true,
+    type: 'success',
+  },
+  {
+    id: '3',
+    title: 'Alerta de inventario',
+    message: 'Quedan pocas unidades del producto X',
+    date: new Date('2025-06-03T09:30:00'),
+    read: false,
+    type: 'warning',
+  },
+];
+
+const meta: Meta<NotificationListProps> = {
+  title: 'Molecules/NotificationList',
+  component: NotificationList,
+  tags: ['autodocs'],
+  argTypes: {
+    notifications: { control: 'object' },
+    maxVisible: { control: 'number' },
+    onItemClick: { action: 'item clicked' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = { args: { notifications: [] } };
+
+export const Mixed: Story = { args: { notifications: baseNotifications } };
+
+export const ManyItems: Story = {
+  args: {
+    notifications: [
+      ...baseNotifications,
+      {
+        id: '4',
+        title: 'Nuevo mensaje',
+        message: 'Tienes un mensaje sin leer',
+        date: new Date('2025-06-04T11:15:00'),
+        read: false,
+        type: 'destructive',
+      },
+      {
+        id: '5',
+        title: 'Actualización',
+        message: 'Se actualizó tu perfil',
+        date: new Date('2025-06-05T08:00:00'),
+        read: true,
+        type: 'info',
+      },
+    ],
+    maxVisible: 3,
+  },
+};

--- a/frontend/src/molecules/NotificationList/NotificationList.test.tsx
+++ b/frontend/src/molecules/NotificationList/NotificationList.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { NotificationList, Notification } from './NotificationList';
+
+const createItems = (count: number): Notification[] =>
+  Array.from({ length: count }).map((_, i) => ({
+    id: String(i),
+    title: `N${i}`,
+    message: 'msg',
+    date: new Date(2025, 5, i + 1),
+    read: false,
+    type: 'info',
+  }));
+
+describe('NotificationList', () => {
+  it('marks item as read when clicked', () => {
+    render(<NotificationList notifications={createItems(1)} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('Nuevo')).not.toBeInTheDocument();
+  });
+
+  it('mark all button updates state', () => {
+    render(<NotificationList notifications={createItems(2)} />);
+    fireEvent.click(screen.getByText('Marcar todo como leído'));
+    expect(screen.queryByText('Nuevo')).not.toBeInTheDocument();
+  });
+
+  it('applies scroll style when exceeding maxVisible', () => {
+    render(<NotificationList notifications={createItems(5)} maxVisible={2} />);
+    const list = screen.getByRole('list');
+    expect(list.style.maxHeight).not.toBe('');
+  });
+});

--- a/frontend/src/molecules/NotificationList/NotificationList.tsx
+++ b/frontend/src/molecules/NotificationList/NotificationList.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { Card } from '@/atoms/Card';
+import { Badge } from '@/atoms/Badge';
+import { Text } from '@/atoms/Text';
+import { Icon } from '@/atoms/Icon';
+import {
+  Info,
+  CheckCircle2,
+  AlertTriangle,
+  AlertCircle,
+} from 'lucide-react';
+
+export interface Notification {
+  id: string;
+  title: string;
+  message: string;
+  date: Date;
+  read: boolean;
+  type?: 'info' | 'success' | 'warning' | 'destructive';
+}
+
+export interface NotificationListProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /** Array of notifications */
+  notifications?: Notification[];
+  /** Maximum number of items visible before scrolling */
+  maxVisible?: number;
+  /** Called when a notification is clicked */
+  onItemClick?: (notification: Notification) => void;
+}
+
+
+export const NotificationList = React.forwardRef<HTMLDivElement, NotificationListProps>(
+  (
+    { notifications = [], maxVisible, onItemClick, className, ...props },
+    ref,
+  ) => {
+    const [items, setItems] = React.useState<Notification[]>([]);
+
+    React.useEffect(() => {
+      const sorted = [...notifications].sort(
+        (a, b) => b.date.getTime() - a.date.getTime(),
+      );
+      setItems(sorted);
+    }, [notifications]);
+
+    const markAsRead = (id: string) => {
+      setItems((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+      );
+    };
+
+    const handleItemClick = (n: Notification) => {
+      markAsRead(n.id);
+      onItemClick?.(n);
+    };
+
+    const handleMarkAll = () => {
+      setItems((prev) => prev.map((n) => ({ ...n, read: true })));
+    };
+
+    const listStyle = React.useMemo(() => {
+      if (!maxVisible || items.length <= maxVisible) return undefined;
+      const itemHeight = 80; // approximate
+      return { maxHeight: itemHeight * maxVisible } as React.CSSProperties;
+    }, [maxVisible, items.length]);
+
+    if (items.length === 0) {
+      return (
+        <div ref={ref} className={cn('p-4 text-center', className)} {...props}>
+          <Text muted>No hay notificaciones</Text>
+        </div>
+      );
+    }
+
+    return (
+      <div ref={ref} className={cn('space-y-2', className)} {...props}>
+        <button
+          type="button"
+          onClick={handleMarkAll}
+          className="ml-auto mb-1 text-sm underline"
+        >
+          Marcar todo como leído
+        </button>
+        <ul
+          role="list"
+          className="notification-list space-y-2 overflow-y-auto"
+          style={listStyle}
+        >
+          {items.map((n) => {
+            const iconEl =
+              n.type === 'success' ? (
+                <CheckCircle2 />
+              ) : n.type === 'warning' ? (
+                <AlertTriangle />
+              ) : n.type === 'destructive' ? (
+                <AlertCircle />
+              ) : (
+                <Info />
+              );
+            return (
+              <li key={n.id} role="listitem" className="notification-item">
+                <Card
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => handleItemClick(n)}
+                  className="flex items-start gap-3 cursor-pointer"
+                >
+                  <Icon aria-label={n.type ?? 'info'}>{iconEl}</Icon>
+                  <div className="flex-1">
+                    <Text as="span" weight="semibold">
+                      {n.title}
+                    </Text>
+                    <Text as="p" size="sm">
+                      {n.message}
+                    </Text>
+                    <Text as="span" size="xs" muted>
+                      {n.date.toLocaleString()}
+                    </Text>
+                  </div>
+                  {!n.read && (
+                    <Badge variant="info" className="ml-2 whitespace-nowrap">
+                      Nuevo
+                    </Badge>
+                  )}
+                </Card>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  },
+);
+NotificationList.displayName = 'NotificationList';
+

--- a/frontend/src/molecules/NotificationList/index.ts
+++ b/frontend/src/molecules/NotificationList/index.ts
@@ -1,0 +1,1 @@
+export * from './NotificationList';


### PR DESCRIPTION
## Summary
- add `NotificationList` molecule with mark-as-read logic
- document NotificationList and stories
- add initial tests

## Testing
- `pnpm exec vitest` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883daa95104832b9846c20cfe22a593