### PR TITLE
Add StatsGroup molecule

### DIFF
--- a/frontend/src/molecules/StatsGroup/StatsGroup.docs.mdx
+++ b/frontend/src/molecules/StatsGroup/StatsGroup.docs.mdx
@@ -1,0 +1,42 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { StatsGroup } from './StatsGroup';
+
+<Meta title="Molecules/StatsGroup" of={StatsGroup} />
+
+# StatsGroup
+
+The `StatsGroup` molecule displays multiple `StatCard` components in a responsive grid. Use it to showcase key performance indicators together.
+
+<Canvas>
+  <Story name="Example">
+    <StatsGroup
+      stats={[
+        { value: '120', label: 'Pedidos', iconName: 'Folder', progress: 60 },
+        { value: '$5k', label: 'Ventas', iconName: 'File', progress: 30 },
+        { value: '24', label: 'Clientes', iconName: 'Users' },
+      ]}
+      withDividers
+    />
+  </Story>
+</Canvas>
+
+## Layout options
+
+<Canvas>
+  <Story name="Row vs Column">
+    <div className="space-y-4">
+      <StatsGroup
+        direction="row"
+        stats={[{ value: '1', label: 'Uno' }, { value: '2', label: 'Dos' }]}
+        withDividers
+      />
+      <StatsGroup
+        direction="column"
+        stats={[{ value: '1', label: 'Uno' }, { value: '2', label: 'Dos' }]}
+        withDividers
+      />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={StatsGroup} />

--- a/frontend/src/molecules/StatsGroup/StatsGroup.stories.tsx
+++ b/frontend/src/molecules/StatsGroup/StatsGroup.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatsGroup, StatsGroupProps } from './StatsGroup';
+import { StatCardProps } from '@/molecules/StatCard';
+
+const sampleStats: StatCardProps[] = [
+  { value: '120', label: 'Pedidos', iconName: 'Folder', progress: 60, trend: 'up', trendValue: '12%' },
+  { value: '$5k', label: 'Ventas', iconName: 'File', progress: 30, trend: 'down', trendValue: '-8%' },
+  { value: '24', label: 'Clientes', iconName: 'Users' },
+];
+
+const meta: Meta<StatsGroupProps> = {
+  title: 'Molecules/StatsGroup',
+  component: StatsGroup,
+  tags: ['autodocs'],
+  argTypes: {
+    direction: { control: 'select', options: ['row', 'column', 'auto'] },
+    withDividers: { control: 'boolean' },
+    live: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Row: Story = {
+  args: {
+    stats: sampleStats,
+    direction: 'row',
+    withDividers: true,
+  },
+};
+
+export const Column: Story = {
+  args: {
+    stats: sampleStats,
+    direction: 'column',
+    withDividers: true,
+  },
+};
+
+export const AutoResponsive: Story = {
+  args: {
+    stats: sampleStats,
+    direction: 'auto',
+    withDividers: true,
+  },
+};

--- a/frontend/src/molecules/StatsGroup/StatsGroup.test.tsx
+++ b/frontend/src/molecules/StatsGroup/StatsGroup.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { StatsGroup } from './StatsGroup';
+
+const stats = [
+  { value: '1', label: 'A' },
+  { value: '2', label: 'B' },
+];
+
+describe('StatsGroup', () => {
+  it('renders provided stat cards', () => {
+    render(<StatsGroup stats={stats} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('uses row layout', () => {
+    const { container } = render(<StatsGroup stats={stats} direction="row" />);
+    expect(container.firstChild).toHaveClass('grid-flow-col');
+  });
+
+  it('uses column layout', () => {
+    const { container } = render(<StatsGroup stats={stats} direction="column" />);
+    expect(container.firstChild).toHaveClass('grid-flow-row');
+  });
+
+  it('uses auto layout classes', () => {
+    const { container } = render(<StatsGroup stats={stats} direction="auto" />);
+    const className = container.firstChild?.getAttribute('class') ?? '';
+    expect(className).toContain('grid-flow-row');
+    expect(className).toContain('sm:grid-flow-col');
+  });
+});

--- a/frontend/src/molecules/StatsGroup/StatsGroup.tsx
+++ b/frontend/src/molecules/StatsGroup/StatsGroup.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+import { StatCard, type StatCardProps } from '@/molecules/StatCard';
+import { Divider } from '@/atoms/Divider';
+
+const statsGroupVariants = cva('grid gap-4', {
+  variants: {
+    direction: {
+      row: 'auto-cols-fr grid-flow-col',
+      column: 'grid-flow-row',
+      auto: 'grid-flow-row sm:auto-cols-fr sm:grid-flow-col',
+    },
+  },
+  defaultVariants: {
+    direction: 'row',
+  },
+});
+
+export interface StatsGroupProps
+  extends React.HTMLAttributes<HTMLElement>,
+    VariantProps<typeof statsGroupVariants> {
+  /** Stat cards to render */
+  stats: StatCardProps[];
+  /** Show dividers between stats */
+  withDividers?: boolean;
+  /** Announce updates to assistive technologies */
+  live?: boolean;
+}
+
+export const StatsGroup = React.forwardRef<HTMLElement, StatsGroupProps>(
+  (
+    {
+      stats,
+      direction,
+      withDividers = false,
+      live = false,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <section
+        ref={ref}
+        aria-live={live ? 'polite' : undefined}
+        className={cn('stats-group', statsGroupVariants({ direction }), className)}
+        {...props}
+      >
+        {stats.map((stat, idx) => (
+          <React.Fragment key={idx}>
+            <StatCard {...stat} />
+            {withDividers && idx < stats.length - 1 && (
+              direction === 'row' ? (
+                <Divider orientation="vertical" className="hidden sm:block" />
+              ) : direction === 'column' ? (
+                <Divider orientation="horizontal" />
+              ) : (
+                <>
+                  <Divider orientation="horizontal" className="sm:hidden" />
+                  <Divider orientation="vertical" className="hidden sm:block" />
+                </>
+              )
+            )}
+          </React.Fragment>
+        ))}
+      </section>
+    );
+  },
+);
+StatsGroup.displayName = 'StatsGroup';
+
+export { statsGroupVariants };

--- a/frontend/src/molecules/StatsGroup/index.ts
+++ b/frontend/src/molecules/StatsGroup/index.ts
@@ -1,0 +1,1 @@
+export * from './StatsGroup';


### PR DESCRIPTION
## Summary
- create StatsGroup molecule with responsive grid
- document StatsGroup usage and options
- add StatsGroup stories for Storybook
- include unit tests for layout variants

## Testing
- `pnpm -C frontend exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883dab37624832b84afbc53297335e3