### PR TITLE
Add RatingStars molecule

### DIFF
--- a/frontend/src/molecules/RatingStars/RatingStars.docs.mdx
+++ b/frontend/src/molecules/RatingStars/RatingStars.docs.mdx
@@ -1,0 +1,29 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { RatingStars } from './RatingStars';
+
+<Meta title="Molecules/RatingStars" of={RatingStars} />
+
+# RatingStars
+
+The `RatingStars` component displays a row of clickable stars for rating content. It supports keyboard navigation and a read-only mode.
+
+<Canvas>
+  <Story name="Editable">
+    {() => {
+      const [val, setVal] = React.useState(3);
+      return <RatingStars value={val} onChange={setVal} />;
+    }}
+  </Story>
+  <Story name="ReadOnly">
+    {() => <RatingStars value={4} readOnly />}
+  </Story>
+  <Story name="Ten Stars">
+    {() => {
+      const [val, setVal] = React.useState(7);
+      return <RatingStars max={10} value={val} onChange={setVal} />;
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={RatingStars} />

--- a/frontend/src/molecules/RatingStars/RatingStars.stories.tsx
+++ b/frontend/src/molecules/RatingStars/RatingStars.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { RatingStars, RatingStarsProps } from './RatingStars';
+
+const meta: Meta<RatingStarsProps> = {
+  title: 'Molecules/RatingStars',
+  component: RatingStars,
+  tags: ['autodocs'],
+  argTypes: {
+    max: { control: 'number' },
+    value: { control: 'number' },
+    readOnly: { control: 'boolean' },
+    size: { control: 'number' },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'quaternary', 'success', 'destructive'],
+    },
+    onChange: { action: 'changed', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [val, setVal] = React.useState(args.value ?? 0);
+    return <RatingStars {...args} value={val} onChange={setVal} />;
+  },
+  args: { value: 3 },
+};
+
+export const ReadOnly: Story = {
+  args: { value: 4, readOnly: true },
+};
+
+export const TenStars: Story = {
+  render: (args) => {
+    const [val, setVal] = React.useState(args.value ?? 0);
+    return <RatingStars {...args} value={val} onChange={setVal} />;
+  },
+  args: { max: 10, value: 7 },
+};

--- a/frontend/src/molecules/RatingStars/RatingStars.test.tsx
+++ b/frontend/src/molecules/RatingStars/RatingStars.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { RatingStars } from './RatingStars';
+
+describe('RatingStars', () => {
+  it('changes value on click', () => {
+    const handle = vi.fn();
+    render(<RatingStars value={2} onChange={handle} />);
+    const third = screen.getByLabelText('3 de 5');
+    fireEvent.click(third);
+    expect(handle).toHaveBeenCalledWith(3);
+  });
+
+  it('navigates with keyboard', () => {
+    const handle = vi.fn();
+    render(<RatingStars value={2} onChange={handle} />);
+    const second = screen.getByLabelText('2 de 5');
+    second.focus();
+    fireEvent.keyDown(second, { key: 'ArrowRight' });
+    expect(handle).toHaveBeenCalledWith(3);
+  });
+});

--- a/frontend/src/molecules/RatingStars/RatingStars.tsx
+++ b/frontend/src/molecules/RatingStars/RatingStars.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Icon } from '@/atoms/Icon';
+
+const starVariants = cva('transition-colors', {
+  variants: {
+    color: {
+      primary: 'text-primary',
+      secondary: 'text-secondary',
+      tertiary: 'text-tertiary',
+      quaternary: 'text-quaternary',
+      success: 'text-success',
+      destructive: 'text-destructive',
+    },
+  },
+  defaultVariants: { color: 'primary' },
+});
+
+export interface RatingStarsProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof starVariants> {
+  /** Maximum number of stars */
+  max?: number;
+  /** Current rating value */
+  value: number;
+  /** Disable interactions */
+  readOnly?: boolean;
+  /** Callback when rating changes */
+  onChange?(val: number): void;
+  /** Size of the star in pixels */
+  size?: number;
+}
+
+export const RatingStars = React.forwardRef<HTMLDivElement, RatingStarsProps>(
+  (
+    {
+      max = 5,
+      value,
+      readOnly = false,
+      onChange,
+      size = 20,
+      color,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const [hover, setHover] = React.useState<number | null>(null);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (readOnly) return;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        const next = Math.min(value + 1, max);
+        onChange?.(next);
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        const prev = Math.max(value - 1, 0);
+        onChange?.(prev);
+      }
+    };
+
+    const stars = Array.from({ length: max }, (_, i) => {
+      const filled = hover !== null ? i < hover + 1 : i < value;
+      const fillPercent = hover !== null ? (i === Math.floor(hover) ? hover % 1 : i < hover ? 1 : 0) : filled ? 1 : 0;
+      return (
+        <button
+          key={i}
+          type="button"
+          role="radio"
+          aria-label={`${i + 1} de ${max}`}
+          aria-checked={i + 1 === value}
+          tabIndex={readOnly ? -1 : i + 1 === value ? 0 : -1}
+          disabled={readOnly}
+          onClick={() => !readOnly && onChange?.(i + 1)}
+          onKeyDown={handleKeyDown}
+          onMouseMove={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            const percent = (e.clientX - rect.left) / rect.width;
+            setHover(i + percent);
+          }}
+          onMouseLeave={() => setHover(null)}
+          className={cn('relative p-0.5', readOnly && 'cursor-default')}
+        >
+          <Icon
+            name="Star"
+            className={cn(
+              'text-muted-foreground',
+              filled && starVariants({ color }),
+            )}
+            style={{ width: size, height: size }}
+          >
+            {fillPercent > 0 && (
+              <svg
+                viewBox="0 0 24 24"
+                className="absolute left-0 top-0 overflow-hidden"
+                style={{ width: size, height: size, clipPath: `inset(0 ${100 - fillPercent * 100}% 0 0)` }}
+              >
+                <path
+                  d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"
+                  fill="currentColor"
+                  stroke="none"
+                />
+              </svg>
+            )}
+          </Icon>
+        </button>
+      );
+    });
+
+    return (
+      <div
+        ref={ref}
+        role="radiogroup"
+        className={cn('rating-stars inline-flex', className)}
+        {...props}
+      >
+        {stars}
+      </div>
+    );
+  },
+);
+RatingStars.displayName = 'RatingStars';
+
+export { starVariants as ratingStarVariants };

--- a/frontend/src/molecules/RatingStars/index.ts
+++ b/frontend/src/molecules/RatingStars/index.ts
@@ -1,0 +1,1 @@
+export * from './RatingStars';


### PR DESCRIPTION
## Summary
- introduce `RatingStars` component for star-based rating input
- add Storybook docs and stories
- cover interactions with unit tests

## Testing
- `pnpm --filter erp_system exec vitest run src/molecules/RatingStars/RatingStars.test.tsx`
- `pnpm --filter erp_system test` *(fails: modalVariants is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6883dac31034832bae35cd09181bcd1a