### PR TITLE
Add ProductListItem molecule

### DIFF
--- a/frontend/src/molecules/ProductListItem/ProductListItem.docs.mdx
+++ b/frontend/src/molecules/ProductListItem/ProductListItem.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { ProductListItem } from './ProductListItem';
+
+<Meta title="Molecules/ProductListItem" of={ProductListItem} />
+
+# ProductListItem
+
+Compact row to display a product with image, name and price. Actions appear on hover.
+
+<Canvas>
+  <Story name="Examples">
+    <ul className="space-y-1 max-w-xs">
+      <ProductListItem id="1" img="https://placehold.co/40" name="Camiseta" price={9.99} />
+      <ProductListItem id="2" img="https://placehold.co/40" name="Producto con nombre muy largo que se trunca" price={29.99} />
+      <ProductListItem id="3" img="https://placehold.co/40" name="Sin acciones" price={14.5} showActions={false} />
+    </ul>
+  </Story>
+</Canvas>
+
+<ArgsTable of={ProductListItem} />

--- a/frontend/src/molecules/ProductListItem/ProductListItem.stories.tsx
+++ b/frontend/src/molecules/ProductListItem/ProductListItem.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProductListItem, ProductListItemProps } from './ProductListItem';
+
+const meta: Meta<ProductListItemProps> = {
+  title: 'Molecules/ProductListItem',
+  component: ProductListItem,
+  tags: ['autodocs'],
+  argTypes: {
+    id: { control: 'text' },
+    img: { control: 'text' },
+    name: { control: 'text' },
+    price: { control: 'number' },
+    currency: { control: 'text' },
+    showActions: { control: 'boolean' },
+    onAdd: { action: 'add', table: { category: 'Events' } },
+    onEdit: { action: 'edit', table: { category: 'Events' } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    id: '1',
+    img: 'https://placehold.co/40',
+    name: 'Camiseta básica',
+    price: 19.99,
+  },
+};
+
+export const LongName: Story = {
+  args: {
+    id: '2',
+    img: 'https://placehold.co/40',
+    name: 'Producto con un nombre extremadamente largo que se trunca',
+    price: 29.99,
+  },
+};
+
+export const WithoutActions: Story = {
+  args: {
+    id: '3',
+    img: 'https://placehold.co/40',
+    name: 'Sin acciones',
+    price: 9.99,
+    showActions: false,
+  },
+};

--- a/frontend/src/molecules/ProductListItem/ProductListItem.test.tsx
+++ b/frontend/src/molecules/ProductListItem/ProductListItem.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ProductListItem } from './ProductListItem';
+
+describe('ProductListItem', () => {
+  it('renders image alt text', () => {
+    render(
+      <ul>
+        <ProductListItem id="1" img="img.png" name="Prod" price={1} />
+      </ul>,
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Prod');
+  });
+
+  it('calls onAdd handler', () => {
+    const onAdd = vi.fn();
+    render(
+      <ul>
+        <ProductListItem id="1" img="img.png" name="Prod" price={1} onAdd={onAdd} />
+      </ul>,
+    );
+    fireEvent.click(screen.getByLabelText('Añadir'));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(
+      <ul>
+        <ProductListItem id="1" img="img.png" name="Prod" price={1} />
+      </ul>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/molecules/ProductListItem/ProductListItem.tsx
+++ b/frontend/src/molecules/ProductListItem/ProductListItem.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+import { Avatar } from '@/atoms/Avatar';
+import { Text } from '@/atoms/Text';
+import { Button } from '@/atoms/Button/Button';
+import { Icon } from '@/atoms/Icon';
+import { Toast } from '@/atoms/Toast';
+
+const itemVariants = cva('flex items-center gap-3 px-3 py-2 rounded-md group', {
+  variants: {
+    showActions: {
+      true: 'justify-between',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    showActions: true,
+  },
+});
+
+export interface ProductListItemProps
+  extends React.HTMLAttributes<HTMLLIElement>,
+    VariantProps<typeof itemVariants> {
+  id: string;
+  img: string;
+  name: string;
+  price: number;
+  currency?: string;
+  onAdd?: () => void;
+  onEdit?: () => void;
+}
+
+export const ProductListItem = React.forwardRef<HTMLLIElement, ProductListItemProps>(
+  (
+    {
+      id,
+      img,
+      name,
+      price,
+      currency = 'USD',
+      onAdd,
+      onEdit,
+      showActions,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const [toastVisible, setToastVisible] = React.useState(false);
+
+    const handleAdd = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onAdd?.();
+      setToastVisible(true);
+    };
+
+    const handleEdit = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onEdit?.();
+    };
+
+    const formatted = new Intl.NumberFormat('es-ES', {
+      style: 'currency',
+      currency,
+    }).format(price);
+
+    return (
+      <>
+        {toastVisible && (
+          <Toast intent="success" onDismiss={() => setToastVisible(false)}>
+            Añadido
+          </Toast>
+        )}
+        <li
+          ref={ref}
+          className={cn(itemVariants({ showActions }), className, 'hover:bg-muted')}
+          {...props}
+        >
+          <Avatar src={img} alt={name} size="sm" className="shrink-0" />
+          <div className="flex-1 overflow-hidden">
+            <Text as="span" weight="medium" className="block truncate">
+              {name}
+            </Text>
+            <Text as="span" weight="semibold" color="secondary">
+              <data value={price}>{formatted}</data>
+            </Text>
+          </div>
+          {showActions && (
+            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              {onEdit && (
+                <Button
+                  variant="icon"
+                  size="sm"
+                  intent="secondary"
+                  aria-label="Editar"
+                  onClick={handleEdit}
+                >
+                  <Icon name="Edit" />
+                </Button>
+              )}
+              {onAdd && (
+                <Button
+                  variant="icon"
+                  size="sm"
+                  intent="primary"
+                  aria-label="Añadir"
+                  onClick={handleAdd}
+                >
+                  <Icon name="Plus" />
+                </Button>
+              )}
+            </div>
+          )}
+        </li>
+      </>
+    );
+  },
+);
+ProductListItem.displayName = 'ProductListItem';
+
+export { itemVariants };

--- a/frontend/src/molecules/ProductListItem/index.ts
+++ b/frontend/src/molecules/ProductListItem/index.ts
@@ -1,0 +1,1 @@
+export * from './ProductListItem';


### PR DESCRIPTION
## Summary
- add `ProductListItem` molecule with toast on add
- include stories, docs and tests

## Testing
- `pnpm exec vitest run frontend/src/molecules/ProductListItem/ProductListItem.test.tsx` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883dac96240832bb7f251a8d517738e