### PR TITLE
Add SidebarMenu molecule

### DIFF
--- a/frontend/src/molecules/SidebarMenu/SidebarMenu.docs.mdx
+++ b/frontend/src/molecules/SidebarMenu/SidebarMenu.docs.mdx
@@ -1,0 +1,37 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { SidebarMenu, NavLink } from './SidebarMenu';
+
+<Meta title="Molecules/SidebarMenu" of={SidebarMenu} />
+
+# SidebarMenu
+
+The `SidebarMenu` component renders a collapsible vertical navigation. It supports simple links and nested sections. When collapsed, only icons are displayed and each item shows a tooltip with its label.
+
+const demoItems: NavLink[] = [
+  { label: 'Inicio', icon: 'Home', path: '/' },
+  {
+    label: 'Proyectos',
+    icon: 'Folder',
+    children: [
+      { label: 'Activos', path: '/proyectos/activos' },
+      { label: 'Archivados', path: '/proyectos/archivados' },
+    ],
+  },
+  { label: 'Reportes', icon: 'BarChart2', path: '/reportes' },
+];
+
+<Canvas>
+  <Story name="Expanded">
+    <SidebarMenu items={demoItems} onNavigate={(p) => alert(p)} />
+  </Story>
+  <Story name="Collapsed">
+    <SidebarMenu items={demoItems} collapsed onNavigate={(p) => alert(p)} />
+  </Story>
+  <Story name="Dark theme">
+    <div className="dark bg-neutral-900 p-4">
+      <SidebarMenu items={demoItems} onNavigate={(p) => alert(p)} />
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={SidebarMenu} />

--- a/frontend/src/molecules/SidebarMenu/SidebarMenu.stories.tsx
+++ b/frontend/src/molecules/SidebarMenu/SidebarMenu.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SidebarMenu, SidebarMenuProps, NavLink } from './SidebarMenu';
+
+const items: NavLink[] = [
+  { label: 'Inicio', icon: 'Home', path: '/' },
+  {
+    label: 'Proyectos',
+    icon: 'Folder',
+    children: [
+      { label: 'Activos', path: '/proyectos/activos' },
+      { label: 'Archivados', path: '/proyectos/archivados' },
+    ],
+  },
+  { label: 'Reportes', icon: 'BarChart2', path: '/reportes' },
+];
+
+const meta: Meta<SidebarMenuProps> = {
+  title: 'Molecules/SidebarMenu',
+  component: SidebarMenu,
+  tags: ['autodocs'],
+  argTypes: {
+    collapsed: { control: 'boolean' },
+    color: {
+      control: 'select',
+      options: ['default', 'primary', 'secondary', 'tertiary', 'quaternary', 'altPrimary'],
+    },
+    onNavigate: { action: 'navigate', table: { category: 'Events' } },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { items },
+};
+
+export const Collapsed: Story = {
+  args: { items, collapsed: true },
+};
+
+export const WithNested: Story = {
+  args: { items },
+};

--- a/frontend/src/molecules/SidebarMenu/SidebarMenu.test.tsx
+++ b/frontend/src/molecules/SidebarMenu/SidebarMenu.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SidebarMenu, NavLink } from './SidebarMenu';
+
+const items: NavLink[] = [
+  { label: 'Inicio', icon: 'Home', path: '/home' },
+];
+
+describe('SidebarMenu', () => {
+  it('toggles collapse state', () => {
+    render(<SidebarMenu items={items} onNavigate={() => {}} />);
+    const toggle = screen.getByRole('button', { name: /collapse menu/i });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-label', 'Expand menu');
+  });
+
+  it('navigates on item click', () => {
+    const onNavigate = vi.fn();
+    render(<SidebarMenu items={items} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Inicio' }));
+    expect(onNavigate).toHaveBeenCalledWith('/home');
+  });
+});

--- a/frontend/src/molecules/SidebarMenu/SidebarMenu.tsx
+++ b/frontend/src/molecules/SidebarMenu/SidebarMenu.tsx
@@ -1,0 +1,182 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { Tooltip } from '@/atoms/Tooltip';
+import { Accordion } from '@/atoms/Accordion';
+
+export interface NavLink {
+  label: string;
+  icon?: IconName;
+  path?: string;
+  children?: NavLink[];
+}
+
+const sidebarVariants = cva(
+  'sidebar-menu flex flex-col h-full border-r border-border bg-background',
+  {
+    variants: {
+      collapsed: {
+        true: 'w-16',
+        false: 'w-60',
+      },
+      color: {
+        default: '',
+        primary: 'bg-primary text-primary-foreground',
+        secondary: 'bg-secondary text-secondary-foreground',
+        tertiary: 'bg-tertiary text-tertiary-foreground',
+        quaternary: 'bg-quaternary text-quaternary-foreground',
+        altPrimary: 'bg-altPrimary text-white',
+      },
+    },
+    defaultVariants: {
+      collapsed: false,
+      color: 'default',
+    },
+  },
+);
+
+const itemVariants = cva(
+  'flex items-center gap-2 w-full rounded-md px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary hover:bg-muted',
+  {
+    variants: {
+      collapsed: {
+        true: 'justify-center p-3',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      collapsed: false,
+    },
+  },
+);
+
+interface SidebarMenuContextValue {
+  collapsed: boolean;
+  open: string[];
+  toggle: (label: string) => void;
+}
+
+const SidebarMenuContext = React.createContext<SidebarMenuContextValue | null>(null);
+
+export interface SidebarMenuProps extends VariantProps<typeof sidebarVariants> {
+  items: NavLink[];
+  collapsed?: boolean;
+  onNavigate: (path: string) => void;
+}
+
+export const SidebarMenu: React.FC<SidebarMenuProps> = ({
+  items,
+  collapsed = false,
+  onNavigate,
+  color,
+  className,
+}) => {
+  const [isCollapsed, setIsCollapsed] = React.useState(collapsed);
+  const [open, setOpen] = React.useState<string[]>([]);
+
+  const toggleCollapse = () => setIsCollapsed((c) => !c);
+  const toggle = (label: string) =>
+    setOpen((prev) => (prev.includes(label) ? prev.filter((l) => l !== label) : [...prev, label]));
+
+  React.useEffect(() => {
+    if (isCollapsed) setOpen([]);
+  }, [isCollapsed]);
+
+  const ctx = React.useMemo(() => ({ collapsed: isCollapsed, open, toggle }), [isCollapsed, open]);
+
+  return (
+    <SidebarMenuContext.Provider value={ctx}>
+      <aside className={cn(sidebarVariants({ collapsed: isCollapsed, color }), className)}>
+        <nav aria-label="Main" className="flex-1 space-y-1 py-2">
+          {items.map((item) => (
+            <SidebarItem key={item.label} item={item} onNavigate={onNavigate} depth={0} />
+          ))}
+        </nav>
+        <button
+          type="button"
+          onClick={toggleCollapse}
+          aria-label={isCollapsed ? 'Expand menu' : 'Collapse menu'}
+          className="m-2 rounded-md p-2 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary"
+        >
+          <Icon name={isCollapsed ? 'ChevronRight' : 'ChevronLeft'} aria-hidden="true" />
+        </button>
+      </aside>
+    </SidebarMenuContext.Provider>
+  );
+};
+SidebarMenu.displayName = 'SidebarMenu';
+
+interface SidebarItemProps {
+  item: NavLink;
+  depth: number;
+  onNavigate: (path: string) => void;
+}
+
+const SidebarItem: React.FC<SidebarItemProps> = ({ item, depth, onNavigate }) => {
+  const ctx = React.useContext(SidebarMenuContext);
+  if (!ctx) return null;
+  const { collapsed, open, toggle } = ctx;
+  const hasChildren = item.children && item.children.length > 0;
+  const paddingLeft = collapsed ? undefined : depth * 16;
+
+  if (hasChildren) {
+    const isOpen = open.includes(item.label);
+    if (collapsed) {
+      return (
+        <Tooltip content={item.label} placement="right">
+          <button
+            type="button"
+            onClick={() => toggle(item.label)}
+            aria-expanded={isOpen}
+            className={cn(itemVariants({ collapsed: true }))}
+          >
+            {item.icon && <Icon name={item.icon} size="md" aria-hidden="true" />}
+          </button>
+        </Tooltip>
+      );
+    }
+    return (
+      <div style={{ paddingLeft }}>
+        <Accordion
+          title={
+            <span className="flex items-center gap-2">
+              {item.icon && <Icon name={item.icon} size="md" aria-hidden="true" />}
+              <span>{item.label}</span>
+            </span>
+          }
+          open={isOpen}
+          onToggle={() => toggle(item.label)}
+        >
+          <div className="space-y-1">
+            {item.children!.map((child) => (
+              <SidebarItem key={child.label} item={child} depth={depth + 1} onNavigate={onNavigate} />
+            ))}
+          </div>
+        </Accordion>
+      </div>
+    );
+  }
+
+  const button = (
+    <button
+      type="button"
+      onClick={() => item.path && onNavigate(item.path)}
+      className={cn(itemVariants({ collapsed }))}
+      style={{ paddingLeft }}
+    >
+      {item.icon && <Icon name={item.icon} size="md" aria-hidden="true" />}
+      {!collapsed && <span className="flex-1 text-left">{item.label}</span>}
+    </button>
+  );
+
+  return collapsed ? (
+    <Tooltip content={item.label} placement="right">
+      {button}
+    </Tooltip>
+  ) : (
+    button
+  );
+};
+
+export { sidebarVariants };

--- a/frontend/src/molecules/SidebarMenu/index.ts
+++ b/frontend/src/molecules/SidebarMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './SidebarMenu';


### PR DESCRIPTION
## Summary
- add new SidebarMenu component with collapsible behaviour
- document SidebarMenu usage in Storybook
- add stories for default, collapsed and nested menus
- include unit tests verifying collapse toggle and navigation

## Testing
- `pnpm --filter erp_system test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883dacfe214832b923424a484ed3072