### PR TITLE
Add AddressForm molecule

### DIFF
--- a/frontend/src/molecules/AddressForm/AddressForm.docs.mdx
+++ b/frontend/src/molecules/AddressForm/AddressForm.docs.mdx
@@ -1,0 +1,35 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { AddressForm } from './AddressForm';
+
+<Meta title="Molecules/AddressForm" of={AddressForm} />
+
+# AddressForm
+
+El `AddressForm` agrupa campos comunes de dirección para envíos o facturación. 
+Permite validar el código postal según el país seleccionado y opcionalmente mostrar un campo de teléfono.
+
+<Canvas>
+  <Story name="Ejemplo">
+    {() => {
+      const [addr, setAddr] = React.useState({
+        line1: '',
+        line2: '',
+        city: '',
+        state: '',
+        country: 'ES',
+        postalCode: '',
+        phone: '',
+      });
+      const countries = [
+        { label: 'España', value: 'ES', postalPattern: '^\\d{5}$', postalMask: '28013' },
+        { label: 'Estados Unidos', value: 'US', postalPattern: '^\\d{5}(?:-\\d{4})?$', postalMask: '90210' },
+      ];
+      return (
+        <AddressForm value={addr} onChange={(v) => setAddr({ ...addr, ...v })} countries={countries} showPhone />
+      );
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={AddressForm} />

--- a/frontend/src/molecules/AddressForm/AddressForm.stories.tsx
+++ b/frontend/src/molecules/AddressForm/AddressForm.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { AddressForm, AddressFormProps, Address } from './AddressForm';
+
+const countries = [
+  { label: 'España', value: 'ES', postalPattern: '^\\d{5}$', postalMask: '28013' },
+  { label: 'Estados Unidos', value: 'US', postalPattern: '^\\d{5}(?:-\\d{4})?$', postalMask: '90210' },
+];
+
+const meta: Meta<AddressFormProps> = {
+  title: 'Molecules/AddressForm',
+  component: AddressForm,
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+    value: { table: { disable: true } },
+    countries: { control: 'object' },
+    showPhone: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Template = (args: AddressFormProps) => {
+  const [addr, setAddr] = React.useState<Address>(args.value);
+  return (
+    <AddressForm
+      {...args}
+      value={addr}
+      onChange={(val) => {
+        setAddr({ ...addr, ...val });
+        args.onChange?.(val);
+      }}
+    />
+  );
+};
+
+export const WithPhone: Story = {
+  render: Template,
+  args: {
+    value: {
+      line1: '',
+      line2: '',
+      city: '',
+      state: '',
+      country: 'ES',
+      postalCode: '',
+      phone: '',
+    },
+    countries,
+    showPhone: true,
+  },
+};
+
+export const Basic: Story = {
+  render: Template,
+  args: {
+    value: {
+      line1: '',
+      line2: '',
+      city: '',
+      state: '',
+      country: 'US',
+      postalCode: '',
+    },
+    countries,
+    showPhone: false,
+  },
+};

--- a/frontend/src/molecules/AddressForm/AddressForm.test.tsx
+++ b/frontend/src/molecules/AddressForm/AddressForm.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AddressForm, Address } from './AddressForm';
+
+const countries = [
+  { label: 'España', value: 'ES', postalPattern: '^\\d{5}$', postalMask: '28013' },
+  { label: 'Estados Unidos', value: 'US', postalPattern: '^\\d{5}(?:-\\d{4})?$', postalMask: '90210' },
+];
+
+const baseAddress: Address = {
+  line1: '',
+  line2: '',
+  city: '',
+  state: '',
+  country: 'ES',
+  postalCode: '',
+  phone: '',
+};
+
+describe('AddressForm', () => {
+  it('fires onChange for each field', () => {
+    const changes: Array<Partial<Address>> = [];
+    render(
+      <AddressForm
+        value={baseAddress}
+        countries={countries}
+        onChange={(val) => changes.push(val)}
+        showPhone
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Dirección'), { target: { value: 'Calle 1' } });
+    fireEvent.change(screen.getByLabelText('Apt/Suite'), { target: { value: '2A' } });
+    fireEvent.change(screen.getByLabelText('Ciudad'), { target: { value: 'Madrid' } });
+    fireEvent.change(screen.getByLabelText('Estado/Provincia'), { target: { value: 'M' } });
+    fireEvent.change(screen.getByLabelText('Código postal'), { target: { value: '28013' } });
+    fireEvent.change(screen.getByLabelText('Teléfono'), { target: { value: '123' } });
+
+    expect(changes.length).toBe(6);
+  });
+
+  it('validates postal code using regex', () => {
+    render(
+      <AddressForm value={baseAddress} countries={countries} onChange={() => {}} />,
+    );
+    const zip = screen.getByLabelText('Código postal');
+    fireEvent.change(zip, { target: { value: 'abc' } });
+    expect(screen.getByRole('alert')).toHaveTextContent('Código postal inválido');
+    fireEvent.change(zip, { target: { value: '28013' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/molecules/AddressForm/AddressForm.tsx
+++ b/frontend/src/molecules/AddressForm/AddressForm.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { Input } from '@/atoms/Input';
+import { FormField } from '@/molecules/FormField';
+import { DropdownSelect } from '@/molecules/DropdownSelect';
+
+export interface Option {
+  label: string;
+  value: string;
+  /** Regex string for postal code validation */
+  postalPattern?: string;
+  /** Placeholder/mask for postal code */
+  postalMask?: string;
+}
+
+export interface Address {
+  line1: string;
+  line2?: string;
+  city: string;
+  state?: string;
+  country: string;
+  postalCode: string;
+  phone?: string;
+}
+
+export interface AddressFormProps {
+  value: Address;
+  onChange: (addr: Partial<Address>) => void;
+  countries: Option[];
+  showPhone?: boolean;
+  className?: string;
+}
+
+export const AddressForm: React.FC<AddressFormProps> = ({
+  value,
+  onChange,
+  countries,
+  showPhone = false,
+  className,
+}) => {
+  const countryOption = React.useMemo(
+    () => countries.find((c) => c.value === value.country),
+    [countries, value.country],
+  );
+  const [zipError, setZipError] = React.useState<string | undefined>();
+
+  const handleChange = (
+    field: keyof Address,
+  ): React.ChangeEventHandler<HTMLInputElement> => (e) => {
+    const val = e.target.value;
+    if (field === 'postalCode' && countryOption?.postalPattern) {
+      const re = new RegExp(countryOption.postalPattern);
+      setZipError(re.test(val) ? undefined : 'Código postal inválido');
+    }
+    onChange({ [field]: val } as Partial<Address>);
+  };
+
+  const handleCountryChange = (val: string | string[]) => {
+    const newCountry = Array.isArray(val) ? val[0] : val;
+    const option = countries.find((c) => c.value === newCountry);
+    if (option?.postalPattern && value.postalCode) {
+      const re = new RegExp(option.postalPattern);
+      setZipError(re.test(value.postalCode) ? undefined : 'Código postal inválido');
+    } else {
+      setZipError(undefined);
+    }
+    onChange({ country: newCountry });
+  };
+
+  return (
+    <form className={className} aria-label="address-form">
+      <div className="space-y-4">
+        <FormField id="line1" label="Dirección" required>
+          <Input
+            value={value.line1}
+            onChange={handleChange('line1')}
+            placeholder="Calle y número"
+          />
+        </FormField>
+        <FormField id="line2" label="Apt/Suite">
+          <Input
+            value={value.line2 ?? ''}
+            onChange={handleChange('line2')}
+            placeholder="Opcional"
+          />
+        </FormField>
+        <FormField id="city" label="Ciudad" required>
+          <Input value={value.city} onChange={handleChange('city')} />
+        </FormField>
+        <FormField id="state" label="Estado/Provincia">
+          <Input value={value.state ?? ''} onChange={handleChange('state')} />
+        </FormField>
+        <FormField id="country" label="País" required>
+          <DropdownSelect
+            options={countries.map((c) => c.label)}
+            selected={countryOption?.label}
+            onChange={(val) => {
+              const option = countries.find((c) => c.label === val);
+              if (option) handleCountryChange(option.value);
+            }}
+          />
+        </FormField>
+        <FormField
+          id="postalCode"
+          label="Código postal"
+          required
+          error={zipError}
+        >
+          <Input
+            value={value.postalCode}
+            placeholder={countryOption?.postalMask}
+            onChange={handleChange('postalCode')}
+            aria-invalid={zipError ? true : undefined}
+          />
+        </FormField>
+        {showPhone && (
+          <FormField id="phone" label="Teléfono">
+            <Input value={value.phone ?? ''} onChange={handleChange('phone')} />
+          </FormField>
+        )}
+      </div>
+    </form>
+  );
+};
+AddressForm.displayName = 'AddressForm';

--- a/frontend/src/molecules/AddressForm/index.ts
+++ b/frontend/src/molecules/AddressForm/index.ts
@@ -1,0 +1,1 @@
+export * from './AddressForm';


### PR DESCRIPTION
## Summary
- implement AddressForm component for capturing shipping address info
- add stories, docs and tests

## Testing
- `pnpm test:frontend` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883dad8f33c832b83677bce07596d58