### PR TITLE
Add ActivityFeed component

### DIFF
--- a/frontend/src/molecules/ActivityFeed/ActivityFeed.docs.mdx
+++ b/frontend/src/molecules/ActivityFeed/ActivityFeed.docs.mdx
@@ -1,0 +1,22 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { ActivityFeed } from './ActivityFeed';
+
+<Meta title="Molecules/ActivityFeed" of={ActivityFeed} />
+
+# ActivityFeed
+
+The `ActivityFeed` component displays recent activity grouped by day in a reverse chronological timeline.
+
+<Canvas>
+  <Story name="Ejemplo">
+    <ActivityFeed
+      items={[
+        { id: '1', date: new Date('2025-07-05T14:32:00'), content: 'Pedido #1042 entregado', icon: 'Check' },
+        { id: '2', date: new Date('2025-07-05T10:15:00'), content: 'Pedido #1042 enviado', icon: 'Truck' },
+        { id: '3', date: new Date('2025-07-04T09:00:00'), content: 'Pedido #1042 creado', icon: 'Plus' },
+      ]}
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={ActivityFeed} />

--- a/frontend/src/molecules/ActivityFeed/ActivityFeed.stories.tsx
+++ b/frontend/src/molecules/ActivityFeed/ActivityFeed.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActivityFeed, type Activity, ActivityFeedProps } from './ActivityFeed';
+
+const meta: Meta<ActivityFeedProps> = {
+  title: 'Molecules/ActivityFeed',
+  component: ActivityFeed,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const sampleItems: Activity[] = [
+  {
+    id: '1',
+    date: new Date('2025-07-05T14:32:00'),
+    content: 'Pedido #1042 entregado',
+    icon: 'Check',
+  },
+  {
+    id: '2',
+    date: new Date('2025-07-05T10:15:00'),
+    content: 'Pedido #1042 enviado',
+    icon: 'Truck',
+  },
+  {
+    id: '3',
+    date: new Date('2025-07-04T09:00:00'),
+    content: 'Pedido #1042 creado',
+    icon: 'Plus',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    items: sampleItems,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};

--- a/frontend/src/molecules/ActivityFeed/ActivityFeed.test.tsx
+++ b/frontend/src/molecules/ActivityFeed/ActivityFeed.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ActivityFeed, type Activity } from './ActivityFeed';
+
+const items: Activity[] = [
+  { id: '1', date: new Date('2025-07-04T09:00:00'), content: 'A' },
+  { id: '2', date: new Date('2025-07-05T10:00:00'), content: 'B' },
+  { id: '3', date: new Date('2025-07-05T12:00:00'), content: 'C' },
+];
+
+describe('ActivityFeed', () => {
+  it('renders dates ordered desc', () => {
+    const { container } = render(<ActivityFeed items={items} />);
+    const headers = container.querySelectorAll('li > time');
+    expect(headers[0].textContent).toBe('05/07/2025');
+    expect(headers[1].textContent).toBe('04/07/2025');
+  });
+});

--- a/frontend/src/molecules/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/src/molecules/ActivityFeed/ActivityFeed.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { TimelineItem } from '@/molecules/TimelineItem';
+import type { IconName } from '@/atoms/Icon';
+
+export interface Activity {
+  id: string;
+  date: Date;
+  content: React.ReactNode;
+  icon?: IconName;
+}
+
+export interface ActivityFeedProps extends React.HTMLAttributes<HTMLOListElement> {
+  /** Array of activity items */
+  items: Activity[];
+}
+
+const formatDate = (date: Date) =>
+  `${date.getDate().toString().padStart(2, '0')}/${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}/${date.getFullYear()}`;
+
+const formatTime = (date: Date) =>
+  `${date.getHours().toString().padStart(2, '0')}:${date
+    .getMinutes()
+    .toString()
+    .padStart(2, '0')}`;
+
+export const ActivityFeed = React.forwardRef<HTMLOListElement, ActivityFeedProps>(
+  ({ items, className, ...props }, ref) => {
+    const sorted = React.useMemo(() => {
+      return [...items].sort((a, b) => b.date.getTime() - a.date.getTime());
+    }, [items]);
+
+    const groups = React.useMemo(() => {
+      const map = new Map<string, Activity[]>();
+      for (const item of sorted) {
+        const key = item.date.toDateString();
+        if (!map.has(key)) map.set(key, []);
+        map.get(key)!.push(item);
+      }
+      return Array.from(map.entries());
+    }, [sorted]);
+
+    return (
+      <ol
+        ref={ref}
+        className={cn('activity-feed space-y-8', className)}
+        aria-label="Actividad reciente"
+        {...props}
+      >
+        {groups.map(([day, acts]) => {
+          const dayDate = new Date(day);
+          return (
+            <li key={day} className="space-y-4">
+              <time
+                dateTime={dayDate.toISOString().split('T')[0]}
+                className="text-sm font-semibold text-muted-foreground"
+              >
+                {formatDate(dayDate)}
+              </time>
+              <ol className="mt-2 space-y-6">
+                {acts.map((act) => (
+                  <TimelineItem
+                    key={act.id}
+                    iconName={act.icon ?? 'Clock'}
+                    title={act.content as any}
+                    date={formatTime(act.date)}
+                  />
+                ))}
+              </ol>
+            </li>
+          );
+        })}
+      </ol>
+    );
+  },
+);
+ActivityFeed.displayName = 'ActivityFeed';

--- a/frontend/src/molecules/ActivityFeed/index.ts
+++ b/frontend/src/molecules/ActivityFeed/index.ts
@@ -1,0 +1,1 @@
+export * from './ActivityFeed';

--- a/frontend/src/molecules/TimelineItem/TimelineItem.tsx
+++ b/frontend/src/molecules/TimelineItem/TimelineItem.tsx
@@ -26,7 +26,7 @@ export interface TimelineItemProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof indicatorVariants> {
   /** Short title describing the event */
-  title: string;
+  title: React.ReactNode;
   /** Additional detail about the event */
   description?: string;
   /** Date or time string associated with the event */


### PR DESCRIPTION
## Summary
- add ActivityFeed molecule displaying activity grouped by day
- extend TimelineItem title prop to accept ReactNode
- document ActivityFeed in Storybook with stories and docs
- add unit test verifying date order

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm install` *(fails: network error)*

------
https://chatgpt.com/codex/tasks/task_e_6883daffbf8c832b89f4d792370bb1dd