### PR TITLE
Add StepForm molecule

### DIFF
--- a/frontend/src/molecules/StepForm/StepForm.docs.mdx
+++ b/frontend/src/molecules/StepForm/StepForm.docs.mdx
@@ -1,0 +1,89 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import React from 'react';
+import { StepForm } from './StepForm';
+import { FormField } from '@/molecules/FormField';
+import { Input } from '@/atoms/Input';
+
+<Meta title="Molecules/StepForm" of={StepForm} />
+
+# StepForm
+
+The `StepForm` component provides a wizard style form with a step indicator,
+dynamic step content and navigation buttons. It validates the active step
+before allowing progress.
+
+<Canvas>
+  <Story name="MultiStepExample">
+    {function Example() {
+      const [current, setCurrent] = React.useState(0);
+      const [values, setValues] = React.useState({ name: '', age: '' });
+
+      const steps = [
+        {
+          id: 'name',
+          label: 'Nombre',
+          content: (
+            <FormField id="name" label="Nombre" required>
+              <Input
+                name="name"
+                value={values.name}
+                onChange={(e) =>
+                  setValues((v) => ({ ...v, name: e.target.value }))
+                }
+              />
+            </FormField>
+          ),
+        },
+        {
+          id: 'age',
+          label: 'Edad',
+          content: (
+            <FormField id="age" label="Edad" required>
+              <Input
+                name="age"
+                type="number"
+                value={values.age}
+                onChange={(e) =>
+                  setValues((v) => ({ ...v, age: e.target.value }))
+                }
+              />
+            </FormField>
+          ),
+        },
+        {
+          id: 'summary',
+          label: 'Resumen',
+          content: (
+            <div className="space-y-1">
+              <p className="text-sm">Nombre: {values.name}</p>
+              <p className="text-sm">Edad: {values.age}</p>
+            </div>
+          ),
+        },
+      ];
+
+      const validateStep = (idx) => {
+        if (idx === 0) return values.name.trim().length > 0;
+        if (idx === 1) return values.age.trim().length > 0;
+        return true;
+      };
+
+      const handleSubmit = () => {
+        // eslint-disable-next-line no-alert
+        alert(JSON.stringify(values));
+      };
+
+      return (
+        <StepForm
+          steps={steps}
+          current={current}
+          validateStep={validateStep}
+          onChangeStep={setCurrent}
+          onSubmit={handleSubmit}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+<ArgsTable of={StepForm} />

--- a/frontend/src/molecules/StepForm/StepForm.stories.tsx
+++ b/frontend/src/molecules/StepForm/StepForm.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { StepForm, StepFormProps, Step } from './StepForm';
+import { FormField } from '@/molecules/FormField';
+import { Input } from '@/atoms/Input';
+
+const meta: Meta<StepFormProps> = {
+  title: 'Molecules/StepForm',
+  component: StepForm,
+  tags: ['autodocs'],
+  argTypes: {
+    steps: { table: { disable: true } },
+    current: { table: { disable: true } },
+    validateStep: { table: { disable: true } },
+    onChangeStep: { table: { disable: true } },
+    onSubmit: { table: { disable: true } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const MultiStepExample: Story = {
+  render: () => {
+    function Demo() {
+      const [current, setCurrent] = useState(0);
+      const [values, setValues] = useState<{ name: string; age: string }>({
+        name: '',
+        age: '',
+      });
+
+      const steps: Step[] = [
+        {
+          id: 'name',
+          label: 'Nombre',
+          content: (
+            <FormField id="name" label="Nombre" required>
+              <Input
+                name="name"
+                value={values.name}
+                onChange={(e) =>
+                  setValues((v) => ({ ...v, name: e.target.value }))
+                }
+              />
+            </FormField>
+          ),
+        },
+        {
+          id: 'age',
+          label: 'Edad',
+          content: (
+            <FormField id="age" label="Edad" required>
+              <Input
+                name="age"
+                type="number"
+                value={values.age}
+                onChange={(e) =>
+                  setValues((v) => ({ ...v, age: e.target.value }))
+                }
+              />
+            </FormField>
+          ),
+        },
+        {
+          id: 'summary',
+          label: 'Resumen',
+          content: (
+            <div className="space-y-1">
+              <p className="text-sm">Nombre: {values.name}</p>
+              <p className="text-sm">Edad: {values.age}</p>
+            </div>
+          ),
+        },
+      ];
+
+      const validateStep = (idx: number) => {
+        if (idx === 0) return values.name.trim().length > 0;
+        if (idx === 1) return values.age.trim().length > 0;
+        return true;
+      };
+
+      const handleSubmit = (vals: unknown) => {
+        // eslint-disable-next-line no-alert
+        alert(JSON.stringify(vals));
+      };
+
+      return (
+        <StepForm
+          steps={steps}
+          current={current}
+          validateStep={validateStep}
+          onChangeStep={setCurrent}
+          onSubmit={handleSubmit}
+        />
+      );
+    }
+    return <Demo />;
+  },
+};

--- a/frontend/src/molecules/StepForm/StepForm.test.tsx
+++ b/frontend/src/molecules/StepForm/StepForm.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { StepForm, Step } from './StepForm';
+
+const steps: Step[] = [
+  { id: 'a', label: 'A', content: <div>Step A</div> },
+  { id: 'b', label: 'B', content: <div>Step B</div> },
+];
+
+describe('StepForm', () => {
+  it('changes step when clicking next', async () => {
+    const handle = vi.fn();
+    render(
+      <StepForm steps={steps} current={0} onChangeStep={handle} onSubmit={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(handle).toHaveBeenCalledWith(1);
+  });
+
+  it('submits on last step', async () => {
+    const submit = vi.fn();
+    render(
+      <StepForm
+        steps={steps}
+        current={1}
+        onChangeStep={vi.fn()}
+        onSubmit={submit}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(submit).toHaveBeenCalled();
+  });
+
+  it('stops when validateStep fails', async () => {
+    const validate = vi.fn(() => false);
+    const handle = vi.fn();
+    render(
+      <StepForm
+        steps={steps}
+        current={0}
+        validateStep={validate}
+        onChangeStep={handle}
+        onSubmit={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(handle).not.toHaveBeenCalled();
+    expect(validate).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/molecules/StepForm/StepForm.tsx
+++ b/frontend/src/molecules/StepForm/StepForm.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { StepIndicator } from '@/molecules/StepIndicator';
+import { Button } from '@/atoms/Button';
+import { cn } from '@/lib/utils';
+
+export interface Step {
+  id: string;
+  label: string;
+  content: React.ReactNode;
+}
+
+export interface StepFormProps extends React.FormHTMLAttributes<HTMLFormElement> {
+  /** Steps configuration */
+  steps: Step[];
+  /** Current active step (0-indexed) */
+  current: number;
+  /** Validate the current step before advancing */
+  validateStep?: (idx: number) => boolean | Promise<boolean>;
+  /** Called when the step changes */
+  onChangeStep: (idx: number) => void;
+  /** Called when submitting the final step */
+  onSubmit: (values: unknown) => void;
+}
+
+export const StepForm = React.forwardRef<HTMLFormElement, StepFormProps>(
+  (
+    { steps, current, validateStep, onChangeStep, onSubmit, className, ...props },
+    ref,
+  ) => {
+    const formRef = React.useRef<HTMLFormElement>(null);
+    React.useImperativeHandle(ref, () => formRef.current as HTMLFormElement);
+
+    const total = steps.length;
+    const safeCurrent = Math.min(Math.max(current, 0), total - 1);
+
+    const handlePrev = () => {
+      if (safeCurrent > 0) onChangeStep(safeCurrent - 1);
+    };
+
+    const getValues = () => {
+      const data = new FormData(formRef.current!);
+      return Object.fromEntries(data.entries());
+    };
+
+    const handleNext = async () => {
+      const isValid = (await validateStep?.(safeCurrent)) ?? true;
+      if (!isValid) return;
+
+      if (safeCurrent < total - 1) {
+        onChangeStep(safeCurrent + 1);
+      } else {
+        onSubmit(getValues());
+      }
+    };
+
+    const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+      e.preventDefault();
+      void handleNext();
+    };
+
+    return (
+      <form
+        ref={formRef}
+        onSubmit={handleSubmit}
+        className={cn('step-form space-y-4', className)}
+        {...props}
+      >
+        <StepIndicator
+          totalSteps={total}
+          currentStep={safeCurrent + 1}
+          labels={steps.map((s) => s.label)}
+          clickable
+          onStepClick={(idx) => onChangeStep(idx - 1)}
+        />
+
+        <section className="step-content">{steps[safeCurrent].content}</section>
+
+        <footer className="actions flex justify-between">
+          <Button
+            type="button"
+            variant="outline"
+            intent="secondary"
+            onClick={handlePrev}
+            disabled={safeCurrent === 0}
+            aria-disabled={safeCurrent === 0}
+          >
+            Prev
+          </Button>
+          <Button type="submit">
+            {safeCurrent < total - 1 ? 'Next' : 'Submit'}
+          </Button>
+        </footer>
+      </form>
+    );
+  },
+);
+StepForm.displayName = 'StepForm';
+

--- a/frontend/src/molecules/StepForm/index.ts
+++ b/frontend/src/molecules/StepForm/index.ts
@@ -1,0 +1,1 @@
+export * from './StepForm';


### PR DESCRIPTION
## Summary
- implement `StepForm` molecule with step navigation
- document usage in Storybook
- add story demonstrating multi-step validation
- provide unit tests for navigation and submission

## Testing
- `pnpm test:frontend` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883db0d811c832bbe8fff32e590ed09