### PR TITLE
Add DashboardWidget molecule

### DIFF
--- a/frontend/src/molecules/DashboardWidget/DashboardWidget.docs.mdx
+++ b/frontend/src/molecules/DashboardWidget/DashboardWidget.docs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { DashboardWidget } from './DashboardWidget';
+
+<Meta title="Molecules/DashboardWidget" of={DashboardWidget} />
+
+# DashboardWidget
+
+A small card for dashboards showing a value, label and optional mini chart or icon. The border color can change with the `variant` prop.
+
+<Canvas>
+  <Story name="With sparkline">
+    <DashboardWidget
+      title="Ingresos"
+      value="$12k"
+      subLabel="Últimos 7 días"
+      chart={<svg width="80" height="24" viewBox="0 0 80 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="0,20 10,10 20,14 30,6 40,12 50,4 60,16 70,8 80,10" /></svg>}
+    />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="With icon">
+    <DashboardWidget title="Errores" value="5" iconName="AlertTriangle" subLabel="Hoy" variant="danger" />
+  </Story>
+</Canvas>
+
+<ArgsTable of={DashboardWidget} />

--- a/frontend/src/molecules/DashboardWidget/DashboardWidget.stories.tsx
+++ b/frontend/src/molecules/DashboardWidget/DashboardWidget.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DashboardWidget, DashboardWidgetProps } from './DashboardWidget';
+import { iconMap, type IconName } from '@/atoms/Icon';
+
+interface WidgetStoryProps extends DashboardWidgetProps {
+  iconName?: IconName;
+}
+
+const iconOptions = Object.keys(iconMap) as IconName[];
+
+const meta: Meta<WidgetStoryProps> = {
+  title: 'Molecules/DashboardWidget',
+  component: DashboardWidget,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'danger'] },
+    iconName: { control: 'select', options: iconOptions },
+    title: { control: 'text' },
+    value: { control: 'text' },
+    subLabel: { control: 'text' },
+    chart: { control: false },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Pedidos',
+    value: '120',
+    subLabel: 'Última semana',
+  },
+};
+
+export const WithChart: Story = {
+  args: {
+    title: 'Ventas',
+    value: '$8k',
+    subLabel: 'Últimos 7 días',
+    chart: (
+      <svg width="80" height="24" viewBox="0 0 80 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <polyline points="0,20 10,10 20,14 30,6 40,12 50,4 60,16 70,8 80,10" />
+      </svg>
+    ),
+  },
+};
+
+export const DangerVariant: Story = {
+  args: {
+    title: 'Errores',
+    value: '5',
+    variant: 'danger',
+    iconName: 'AlertTriangle',
+    subLabel: 'Hoy',
+  },
+};

--- a/frontend/src/molecules/DashboardWidget/DashboardWidget.test.tsx
+++ b/frontend/src/molecules/DashboardWidget/DashboardWidget.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { DashboardWidget } from './DashboardWidget';
+
+describe('DashboardWidget', () => {
+  it('renders title and value', () => {
+    render(<DashboardWidget title="Ventas" value="100" />);
+    expect(screen.getByText('Ventas')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+  });
+
+  it('matches snapshot with chart', () => {
+    const { container } = render(
+      <DashboardWidget
+        title="Ventas"
+        value="100"
+        chart={<svg><circle cx="5" cy="5" r="5" /></svg>}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/molecules/DashboardWidget/DashboardWidget.tsx
+++ b/frontend/src/molecules/DashboardWidget/DashboardWidget.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { Card, type CardProps } from '@/atoms/Card';
+import { Heading } from '@/atoms/Heading';
+import { Text } from '@/atoms/Text';
+import { Icon, type IconName } from '@/atoms/Icon';
+import { cn } from '@/lib/utils';
+
+const widgetVariants = cva('dashboard-widget transition-shadow', {
+  variants: {
+    variant: {
+      default: 'border-border',
+      danger: 'border-destructive',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export interface DashboardWidgetProps
+  extends Omit<CardProps, 'children'>,
+    VariantProps<typeof widgetVariants> {
+  /** Title displayed at the top */
+  title: string;
+  /** Main numeric or textual value */
+  value: string | number;
+  /** Small caption under the chart */
+  subLabel?: string;
+  /** Optional icon to show when no chart is provided */
+  iconName?: IconName;
+  /** Optional mini chart element */
+  chart?: React.ReactNode;
+}
+
+export const DashboardWidget = React.forwardRef<HTMLDivElement, DashboardWidgetProps>(
+  (
+    { title, value, subLabel, iconName, chart, variant, className, ...props },
+    ref,
+  ) => {
+    const valueId = React.useId();
+    return (
+      <Card
+        ref={ref}
+        role="figure"
+        aria-describedby={valueId}
+        variant="outline"
+        className={cn(
+          'flex flex-col items-start gap-1 hover:shadow-md',
+          widgetVariants({ variant }),
+          className,
+        )}
+        {...props}
+      >
+        <Heading level={6} as="h3" className="font-semibold">
+          {title}
+        </Heading>
+        <Text id={valueId} as="span" className="text-3xl font-semibold">
+          {value}
+        </Text>
+        {chart ? (
+          <div className="w-full" data-testid="chart">
+            {chart}
+          </div>
+        ) : (
+          iconName && (
+            <Icon name={iconName} className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          )
+        )}
+        {subLabel && (
+          <Text as="span" size="sm" muted>
+            {subLabel}
+          </Text>
+        )}
+      </Card>
+    );
+  },
+);
+DashboardWidget.displayName = 'DashboardWidget';
+
+export { widgetVariants as dashboardWidgetVariants };

--- a/frontend/src/molecules/DashboardWidget/__snapshots__/DashboardWidget.test.tsx.snap
+++ b/frontend/src/molecules/DashboardWidget/__snapshots__/DashboardWidget.test.tsx.snap
@@ -1,0 +1,35 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DashboardWidget > matches snapshot with chart 1`] = `
+<div>
+  <div
+    aria-describedby=":r1:"
+    class="rounded-md border bg-white p-4 text-foreground shadow-none flex flex-col items-start gap-1 hover:shadow-md dashboard-widget transition-shadow border-border"
+    role="figure"
+  >
+    <h3
+      class="font-heading text-lg tracking-tight text-left text-primary font-semibold"
+    >
+      Ventas
+    </h3>
+    <span
+      class="font-sans text-3xl font-semibold"
+      id=":r1:"
+    >
+      100
+    </span>
+    <div
+      class="w-full"
+      data-testid="chart"
+    >
+      <svg>
+        <circle
+          cx="5"
+          cy="5"
+          r="5"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/molecules/DashboardWidget/index.ts
+++ b/frontend/src/molecules/DashboardWidget/index.ts
@@ -1,0 +1,1 @@
+export * from './DashboardWidget';


### PR DESCRIPTION
## Summary
- create DashboardWidget component for dashboard metrics
- add Storybook docs and stories
- provide unit tests and snapshot

## Testing
- `npx vitest run src/molecules/DashboardWidget/DashboardWidget.test.tsx`
- `npx vitest run` *(fails: ConfirmationDialog tests)*

------
https://chatgpt.com/codex/tasks/task_e_6883db2360a0832bafc7e102394a4135