### PR TITLE
Add docs for core form atoms

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -8,7 +8,10 @@ const __dirname = path.dirname(__filename);
 
 const config = {
   framework: "@storybook/react-vite",
-  stories: ["../src/**/*.stories.@(js|jsx|ts|tsx|mdx)"],
+  stories: [
+    "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
+    "../src/**/*.docs.mdx",
+  ],
   addons: ["@storybook/addon-essentials"],
   core: { disableTelemetry: true },
   async viteFinal(config) {

--- a/frontend/src/atoms/Button/Button.docs.mdx
+++ b/frontend/src/atoms/Button/Button.docs.mdx
@@ -1,0 +1,20 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Button } from './Button';
+
+<Meta title="Atoms/Button" of={Button} />
+
+# Button
+
+The `Button` component triggers an action or event. Use the `variant`, `intent` and `size` props to adjust its style and importance.
+
+<Canvas>
+  <Story name="Examples">
+    <div className="flex items-center gap-4">
+      <Button>Primary</Button>
+      <Button intent="secondary">Secondary</Button>
+      <Button variant="outline" intent="tertiary">Outline</Button>
+    </div>
+  </Story>
+</Canvas>
+
+<ArgsTable of={Button} />

--- a/frontend/src/atoms/Checkbox/Checkbox.docs.mdx
+++ b/frontend/src/atoms/Checkbox/Checkbox.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Checkbox } from './Checkbox';
+
+<Meta title="Atoms/Checkbox" of={Checkbox} />
+
+# Checkbox
+
+The `Checkbox` component lets users select or toggle an option. It supports an indeterminate state and different sizes and intents.
+
+<Canvas>
+  <Story name="Example">
+    <Checkbox label="Accept terms" />
+  </Story>
+</Canvas>
+
+<ArgsTable of={Checkbox} />

--- a/frontend/src/atoms/Input/Input.docs.mdx
+++ b/frontend/src/atoms/Input/Input.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Input } from './Input';
+
+<Meta title="Atoms/Input" of={Input} />
+
+# Input
+
+The `Input` component captures a single line of text. It supports labels, icons and error states for building accessible forms.
+
+<Canvas>
+  <Story name="Example">
+    <Input label="Name" placeholder="John Doe" />
+  </Story>
+</Canvas>
+
+<ArgsTable of={Input} />

--- a/frontend/src/atoms/Textarea/Textarea.docs.mdx
+++ b/frontend/src/atoms/Textarea/Textarea.docs.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Textarea } from './Textarea';
+
+<Meta title="Atoms/Textarea" of={Textarea} />
+
+# Textarea
+
+The `Textarea` component allows users to enter multi-line text. It can auto-resize and show a character counter.
+
+<Canvas>
+  <Story name="Example">
+    <Textarea label="Message" placeholder="Type your message..." />
+  </Story>
+</Canvas>
+
+<ArgsTable of={Textarea} />


### PR DESCRIPTION
## Summary
- add Button docs
- add Checkbox docs
- add Input docs
- add Textarea docs
- include `docs.mdx` files in Storybook config

## Testing
- `pnpm --filter erp_system lint` *(fails: eslint not found)*
- `pnpm --filter erp_system test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_688528dce36c832baf105b15c76443fd