### PR TITLE
Fix Storybook module fetch error

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,25 +1,21 @@
 /** @type { import('@storybook/react-vite').StorybookConfig } */
-import { mergeConfig } from 'vite';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { mergeConfig } from "vite";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const config = {
   framework: "@storybook/react-vite",
-  stories: [
-    "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)",
-    "../src/**/*.docs.mdx",
-  ],
+  stories: ["../src/**/*.stories.@(js|jsx|ts|tsx|mdx)", "../src/**/*.docs.mdx"],
   addons: ["@storybook/addon-essentials"],
   core: { disableTelemetry: true },
   async viteFinal(config) {
     return mergeConfig(config, {
-      root: path.resolve(__dirname, '..'),
       resolve: {
         alias: {
-          '@': path.resolve(__dirname, '../src'),
+          "@": path.resolve(__dirname, "../src"),
         },
       },
     });


### PR DESCRIPTION
## Summary
- clean up `.storybook` Vite config

This removes the `root` override in Storybook's Vite config to avoid failing module imports during runtime.

## Testing
- `npx prettier -w frontend/.storybook/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68867093b810832b9dc5b8e57c663fa7