### PR TITLE
Fix NotificationIcon color

### DIFF
--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.docs.mdx
@@ -5,7 +5,7 @@ import { NotificationIcon } from './NotificationIcon';
 
 # NotificationIcon
 
-The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications. The count text inside the badge is always black using `!text-black`, ensuring readability across all color variants. Large counts are positioned to the right of the icon so they never cover it.
+The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing the number of unread notifications. The icon itself is black by default using the `primary` color variant and the count text inside the badge is always black with `!text-black`, ensuring readability across all color variants. Large counts are positioned to the right of the icon so they never cover it.
 
 <Canvas>
   <Story name="Examples">
@@ -26,6 +26,12 @@ The `NotificationIcon` displays a bell (or any chosen icon) with a badge showing
       <NotificationIcon color="destructive" count={3} />
       <NotificationIcon color="info" count={3} />
     </div>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Custom icon color">
+    <NotificationIcon iconColor="secondary" count={4} />
   </Story>
 </Canvas>
 

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.test.tsx
@@ -24,6 +24,12 @@ describe('NotificationIcon', () => {
     expect(screen.getByText('99+')).toBeInTheDocument();
   });
 
+  it('icon is black by default', () => {
+    render(<NotificationIcon count={1} />);
+    const icon = screen.getByRole('button').querySelector('svg');
+    expect(icon).toHaveClass('text-primary');
+  });
+
   it('badge text is black for all variants', () => {
     const variants = ['neutral', 'success', 'warning', 'destructive', 'info'] as const;
     variants.forEach((variant) => {

--- a/frontend/src/molecules/NotificationIcon/NotificationIcon.tsx
+++ b/frontend/src/molecules/NotificationIcon/NotificationIcon.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
-import { Icon, type IconName } from '@/atoms/Icon';
+import { Icon, type IconName, iconVariants } from '@/atoms/Icon';
+import type { VariantProps } from 'class-variance-authority';
 import { Badge, type BadgeProps } from '@/atoms/Badge';
 
 export interface NotificationIconProps
@@ -13,11 +14,13 @@ export interface NotificationIconProps
   color?: BadgeProps['variant'];
   /** Size of the icon */
   size?: 'sm' | 'md' | 'lg';
+  /** Color of the icon */
+  iconColor?: VariantProps<typeof iconVariants>['color'];
 }
 
 export const NotificationIcon = React.forwardRef<HTMLButtonElement, NotificationIconProps>(
   (
-    { count = 0, iconName = 'Bell', color = 'destructive', size = 'md', className, ...props },
+    { count = 0, iconName = 'Bell', color = 'destructive', size = 'md', iconColor = 'primary', className, ...props },
     ref,
   ) => {
     const showBadge = count > 0;
@@ -30,7 +33,7 @@ export const NotificationIcon = React.forwardRef<HTMLButtonElement, Notification
         className={cn('relative inline-flex', className)}
         {...props}
       >
-        <Icon name={iconName} size={size} aria-hidden="true" />
+        <Icon name={iconName} size={size} color={iconColor} aria-hidden="true" />
         {showBadge && (
           <Badge
             variant={color}


### PR DESCRIPTION
## Summary
- ensure NotificationIcon icon is black by default
- document how to change NotificationIcon icon color
- test default icon color

## Testing
- `pnpm --filter erp_system exec vitest run src/molecules/NotificationIcon/NotificationIcon.test.tsx`
- `pnpm test:frontend` *(fails: Modal and other tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_688672fa6b00832b81b4d8b130910a96