### PR TITLE
Improve SidebarMenu design

### DIFF
--- a/frontend/src/atoms/Icon/icons.ts
+++ b/frontend/src/atoms/Icon/icons.ts
@@ -29,6 +29,12 @@ import {
   TrendingUp,
   TrendingDown,
   X,
+  LayoutDashboard,
+  ShoppingCart,
+  Users,
+  Megaphone,
+  Database,
+  BarChart2,
 } from 'lucide-react';
 
 export const iconMap = {
@@ -62,6 +68,12 @@ export const iconMap = {
   TrendingUp,
   TrendingDown,
   X,
+  LayoutDashboard,
+  ShoppingCart,
+  Users,
+  Megaphone,
+  Database,
+  BarChart2,
 };
 
 export type IconName = keyof typeof iconMap;

--- a/frontend/src/molecules/SidebarMenu/SidebarMenu.docs.mdx
+++ b/frontend/src/molecules/SidebarMenu/SidebarMenu.docs.mdx
@@ -8,16 +8,33 @@ import { SidebarMenu, NavLink } from './SidebarMenu';
 The `SidebarMenu` component renders a collapsible vertical navigation. It supports simple links and nested sections. When collapsed, only icons are displayed and each item shows a tooltip with its label.
 
 const demoItems: NavLink[] = [
-  { label: 'Inicio', icon: 'Home', path: '/' },
+  { label: 'Dashboard', icon: 'LayoutDashboard', path: '/' },
   {
-    label: 'Proyectos',
-    icon: 'Folder',
+    label: 'Ventas',
+    icon: 'ShoppingCart',
     children: [
-      { label: 'Activos', path: '/proyectos/activos' },
-      { label: 'Archivados', path: '/proyectos/archivados' },
+      { label: 'Pedidos', path: '/ventas/pedidos' },
+      { label: 'Facturas', path: '/ventas/facturas' },
+    ],
+  },
+  {
+    label: 'Clientes',
+    icon: 'Users',
+    children: [
+      { label: 'Lista', path: '/clientes' },
+      { label: 'Segmentos', path: '/clientes/segmentos' },
+    ],
+  },
+  {
+    label: 'Marketing',
+    icon: 'Megaphone',
+    children: [
+      { label: 'Campañas', path: '/marketing/campanas' },
+      { label: 'CDP', path: '/marketing/cdp' },
     ],
   },
   { label: 'Reportes', icon: 'BarChart2', path: '/reportes' },
+  { label: 'Ajustes', icon: 'Settings', path: '/ajustes' },
 ];
 
 <Canvas>

--- a/frontend/src/molecules/SidebarMenu/SidebarMenu.tsx
+++ b/frontend/src/molecules/SidebarMenu/SidebarMenu.tsx
@@ -13,7 +13,7 @@ export interface NavLink {
 }
 
 const sidebarVariants = cva(
-  'sidebar-menu flex flex-col h-full border-r border-border bg-background',
+  'sidebar-menu flex flex-col h-full border-r border-border bg-background glass shadow-glass',
   {
     variants: {
       collapsed: {
@@ -37,11 +37,11 @@ const sidebarVariants = cva(
 );
 
 const itemVariants = cva(
-  'flex items-center gap-2 w-full rounded-md px-3 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary hover:bg-muted',
+  'flex items-center gap-3 w-full rounded-md px-4 py-2.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary hover:bg-muted',
   {
     variants: {
       collapsed: {
-        true: 'justify-center p-3',
+        true: 'justify-center p-3.5',
         false: '',
       },
     },
@@ -88,7 +88,7 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
   return (
     <SidebarMenuContext.Provider value={ctx}>
       <aside className={cn(sidebarVariants({ collapsed: isCollapsed, color }), className)}>
-        <nav aria-label="Main" className="flex-1 space-y-1 py-2">
+        <nav aria-label="Main" className="flex-1 space-y-2 py-3">
           {items.map((item) => (
             <SidebarItem key={item.label} item={item} onNavigate={onNavigate} depth={0} />
           ))}
@@ -118,7 +118,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({ item, depth, onNavigate }) =>
   if (!ctx) return null;
   const { collapsed, open, toggle } = ctx;
   const hasChildren = item.children && item.children.length > 0;
-  const paddingLeft = collapsed ? undefined : depth * 16;
+  const paddingLeft = collapsed ? undefined : depth * 20;
 
   if (hasChildren) {
     const isOpen = open.includes(item.label);
@@ -148,7 +148,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({ item, depth, onNavigate }) =>
           open={isOpen}
           onToggle={() => toggle(item.label)}
         >
-          <div className="space-y-1">
+          <div className="space-y-2">
             {item.children!.map((child) => (
               <SidebarItem key={child.label} item={child} depth={depth + 1} onNavigate={onNavigate} />
             ))}


### PR DESCRIPTION
## Summary
- apply liquid glass style to SidebarMenu
- tweak item padding and spacing for better readability
- update demo items with ERP/CRM oriented examples
- extend icon map with additional Lucide icons

## Testing
- `pnpm exec vitest run src/molecules/SidebarMenu/SidebarMenu.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6886755eac28832bbb1aac47c2b153f1