### PR TITLE
Fix Storybook config for React

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,5 +1,6 @@
 /** @type { import('@storybook/react-vite').StorybookConfig } */
 import { mergeConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -16,6 +17,7 @@ const config = {
   core: { disableTelemetry: true },
   async viteFinal(config) {
     return mergeConfig(config, {
+      plugins: [react()],
       root: path.resolve(__dirname, '..'),
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- include `@vitejs/plugin-react` in Storybook config so stories are compiled correctly

## Testing
- `pnpm test` *(fails: storybook command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68867093b810832b9dc5b8e57c663fa7