### PR TITLE
Implement submenus and theme switcher

### DIFF
--- a/frontend/src/atoms/Icon/icons.ts
+++ b/frontend/src/atoms/Icon/icons.ts
@@ -36,6 +36,8 @@ import {
   Megaphone,
   Database,
   BarChart2,
+  Sun,
+  Moon,
 } from 'lucide-react';
 
 export const iconMap = {
@@ -76,6 +78,8 @@ export const iconMap = {
   Megaphone,
   Database,
   BarChart2,
+  Sun,
+  Moon,
 };
 
 export type IconName = keyof typeof iconMap;

--- a/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.docs.mdx
+++ b/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.docs.mdx
@@ -1,0 +1,12 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { ThemeSwitcher } from './ThemeSwitcher';
+
+<Meta title="Atoms/ThemeSwitcher" of={ThemeSwitcher} />
+
+# ThemeSwitcher
+
+Simple button to toggle light/dark themes by adding or removing the `dark` class on the `html` element.
+
+<Canvas><Story name="Default"><ThemeSwitcher /></Story></Canvas>
+
+<ArgsTable of={ThemeSwitcher} />

--- a/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.stories.tsx
+++ b/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ThemeSwitcher } from './ThemeSwitcher';
+
+const meta: Meta<typeof ThemeSwitcher> = {
+  title: 'Atoms/ThemeSwitcher',
+  component: ThemeSwitcher,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.test.tsx
+++ b/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ThemeSwitcher } from './ThemeSwitcher';
+
+describe('ThemeSwitcher', () => {
+  it('toggles dark class on click', () => {
+    render(<ThemeSwitcher />);
+    const btn = screen.getByRole('button');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    fireEvent.click(btn);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/frontend/src/atoms/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Button } from '@/atoms/Button';
+import { Icon } from '@/atoms/Icon';
+
+export interface ThemeSwitcherProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const ThemeSwitcher = React.forwardRef<HTMLButtonElement, ThemeSwitcherProps>(
+  ({ className, ...props }, ref) => {
+    const [dark, setDark] = React.useState(() =>
+      typeof document !== 'undefined' && document.documentElement.classList.contains('dark'),
+    );
+
+    React.useEffect(() => {
+      if (dark) document.documentElement.classList.add('dark');
+      else document.documentElement.classList.remove('dark');
+    }, [dark]);
+
+    const toggle = () => setDark((d) => !d);
+
+    return (
+      <Button
+        variant="icon"
+        size="sm"
+        onClick={toggle}
+        aria-label="Toggle theme"
+        ref={ref}
+        className={className}
+        {...props}
+      >
+        <Icon name={dark ? 'Sun' : 'Moon'} aria-hidden="true" />
+      </Button>
+    );
+  },
+);
+ThemeSwitcher.displayName = 'ThemeSwitcher';

--- a/frontend/src/atoms/ThemeSwitcher/index.ts
+++ b/frontend/src/atoms/ThemeSwitcher/index.ts
@@ -1,0 +1,1 @@
+export * from './ThemeSwitcher';

--- a/frontend/src/organisms/GlobalHeader/GlobalHeader.stories.tsx
+++ b/frontend/src/organisms/GlobalHeader/GlobalHeader.stories.tsx
@@ -36,6 +36,17 @@ const baseItems = [
   { label: 'Customers', iconName: 'Users', path: '/customers' },
 ];
 
+const submenuItems = [
+  {
+    label: 'Reports',
+    iconName: 'BarChart2',
+    children: [
+      { label: 'Sales', path: '/reports/sales' },
+      { label: 'Inventory', path: '/reports/inventory' },
+    ],
+  },
+];
+
 export const Default: Story = {
   args: {
     logo: 'Fashion',
@@ -69,5 +80,12 @@ export const CustomColors: Story = {
     ...Default.args,
     color: 'primary',
     variant: 'glass',
+  },
+};
+
+export const WithSubmenus: Story = {
+  args: {
+    ...Default.args,
+    navItems: [...baseItems, ...submenuItems],
   },
 };

--- a/frontend/src/organisms/GlobalHeader/GlobalHeader.test.tsx
+++ b/frontend/src/organisms/GlobalHeader/GlobalHeader.test.tsx
@@ -7,6 +7,14 @@ const items = [
   { label: 'Users', iconName: 'Users', path: '/users' },
 ];
 
+const submenu = [
+  {
+    label: 'Reports',
+    iconName: 'BarChart2' as const,
+    children: [{ label: 'Sales', path: '/reports/sales' }],
+  },
+];
+
 const resize = (w: number) => {
   act(() => {
     window.innerWidth = w;
@@ -30,6 +38,7 @@ describe('GlobalHeader', () => {
     expect(screen.getByText('Logo')).toBeInTheDocument();
     expect(screen.getByRole('search')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Notifications' })).toBeInTheDocument();
+    expect(screen.getByText('Ana')).toBeInTheDocument();
   });
 
   it('calls callbacks', () => {
@@ -65,5 +74,14 @@ describe('GlobalHeader', () => {
     resize(1100);
     expect(screen.queryByLabelText('Menu')).not.toBeInTheDocument();
     expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('navigates via submenu', () => {
+    const onNav = vi.fn();
+    resize(1280);
+    render(<GlobalHeader navItems={submenu} onNavigate={onNav} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
+    fireEvent.click(screen.getByText('Sales'));
+    expect(onNav).toHaveBeenCalledWith('/reports/sales');
   });
 });


### PR DESCRIPTION
## Summary
- make `glass` the default header variant
- add `ThemeSwitcher` atom
- show username in `GlobalHeader`
- add submenu dropdowns and active states
- add search dialog for small screens
- update stories and tests

## Testing
- `pnpm --filter erp_system test --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d5978a18832ba96438ddab549178